### PR TITLE
Fix/schematic port

### DIFF
--- a/src/lib/soup-to-svg.ts
+++ b/src/lib/soup-to-svg.ts
@@ -1,74 +1,80 @@
 import type { AnySoupElement } from "@tscircuit/soup";
 
 function soupToSvg(soup: AnySoupElement[]): string {
-  const svgContent: string[] = [];
   let minX = Number.POSITIVE_INFINITY;
   let minY = Number.POSITIVE_INFINITY;
   let maxX = Number.NEGATIVE_INFINITY;
   let maxY = Number.NEGATIVE_INFINITY;
 
-  // Process components
-  for (const component of soup.filter(
-    (item) => item.type === "schematic_component"
-  )) {
-    const svg = createSchematicComponent(component);
-    svgContent.push(svg);
-    if (
-      "center" in component &&
-      "size" in component &&
-      "rotation" in component
-    ) {
-      updateBounds(component.center, component.size, component.rotation);
+  // First pass: find the bounds
+  for (const item of soup) {
+    if ('center' in item) {
+      updateBounds(item.center, item.size || {width: 0.2, height: 0.2}, item.rotation || 0);
+    } else if ('position' in item) {
+      updateBounds(item.position, {width: 0, height: 0}, 0);
     }
   }
 
-  // Process traces
-  for (const trace of soup.filter((item) => item.type === "schematic_trace")) {
-    const svg = createSchematicTrace(trace);
+  const height = maxY - minY;
+
+  // Function to flip y-coordinate
+  const flipY = (y: number) => height - (y - minY) + minY;
+
+  const svgContent: string[] = [];
+
+  // Process ports
+  const portPositions = new Map();
+  for (const port of soup.filter((item) => item.type === "schematic_port")) {
+    const flippedCenter = { x: port.center.x, y: flipY(port.center.y) };
+    const svg = createSchematicPort(flippedCenter);
     svgContent.push(svg);
-    updateTraceBounds(trace.edges);
+    portPositions.set(port.schematic_port_id, flippedCenter);
+  }
+
+  // Process components
+  for (const component of soup.filter((item) => item.type === "schematic_component")) {
+    const flippedCenter = { x: component.center.x, y: flipY(component.center.y) };
+    const svg = createSchematicComponent(flippedCenter, component.size, -component.rotation);
+    svgContent.push(svg);
+  }
+
+  // Process schematic traces
+  for (const trace of soup.filter((item) => item.type === "schematic_trace")) {
+    const svg = createSchematicTrace(trace, flipY, portPositions);
+    svgContent.push(svg);
   }
 
   // Process text
   for (const text of soup.filter((item) => item.type === "schematic_text")) {
-    const svg = createSchematicText(text);
+    const flippedPosition = { x: text.position.x, y: flipY(text.position.y) };
+    const svg = createSchematicText(text, flippedPosition);
     svgContent.push(svg);
-    if ("position" in text) {
-      updateTextBounds(text.position);
-    }
   }
 
   // Process net labels
-  for (const label of soup.filter(
-    (item) => item.type === "schematic_net_label"
-  )) {
-    const svg = createSchematicNetLabel(label);
+  for (const label of soup.filter((item) => item.type === "schematic_net_label")) {
+    const flippedCenter = { x: label.center.x, y: flipY(label.center.y) };
+    const svg = createSchematicNetLabel(label, flippedCenter);
     svgContent.push(svg);
-    const width = label.text.length * 0.15 + 0.3;
-    const height = 0.3;
-    minX = Math.min(minX, label.center.x);
-    minY = Math.min(minY, label.center.y - height / 2);
-    maxX = Math.max(maxX, label.center.x + width);
-    maxY = Math.max(maxY, label.center.y + height / 2);
   }
 
   const padding = 1;
   const width = maxX - minX + 2 * padding;
-  const height = maxY - minY + 2 * padding;
-  const viewBox = `${minX - padding} ${minY - padding} ${width} ${height}`;
+  const viewBox = `${minX - padding} ${minY - padding} ${width} ${height + 2 * padding}`;
 
   return `
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="${viewBox}" width="1200" height="600">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="${viewBox}" width="1200" height="600">
       <style>
-      .component { fill: none; stroke: red; stroke-width: 0.05; }
-      .component-pin { fill: none; stroke: blue; stroke-width: 0.05; }
-      .trace { stroke: green; stroke-width: 0.05; fill: none; }
-      .text { font-family: Arial, sans-serif; font-size: 0.2px; }
-      .net-label { font-family: Arial, sans-serif; font-size: 0.2px; fill: gray; }
-    </style>
-        ${svgContent.join("\n")}
-      </svg>
-    `;
+        .component { fill: none; stroke: red; stroke-width: 0.03; }
+        .component-pin { fill: none; stroke: blue; stroke-width: 0.05; }
+        .trace { stroke: green; stroke-width: 0.03; fill: none; }
+        .text { font-family: Arial, sans-serif; font-size: 0.2px; }
+        .net-label { font-family: Arial, sans-serif; font-size: 0.2px; fill: gray; }
+        .port { fill: none; stroke: blue; stroke-width: 0.03; }
+      </style>
+      ${svgContent.join("\n")}
+    </svg>
+  `;
 
   function updateBounds(center: any, size: any, rotation: number) {
     const corners = [
@@ -79,140 +85,118 @@ function soupToSvg(soup: AnySoupElement[]): string {
     ];
 
     for (const corner of corners) {
-      const rotatedX =
-        corner.x * Math.cos(rotation) -
-        corner.y * Math.sin(rotation) +
-        center.x;
-      const rotatedY =
-        corner.x * Math.sin(rotation) +
-        corner.y * Math.cos(rotation) +
-        center.y;
+      const rotatedX = corner.x * Math.cos(rotation) - corner.y * Math.sin(rotation) + center.x;
+      const rotatedY = corner.x * Math.sin(rotation) + corner.y * Math.cos(rotation) + center.y;
       minX = Math.min(minX, rotatedX);
       minY = Math.min(minY, rotatedY);
       maxX = Math.max(maxX, rotatedX);
       maxY = Math.max(maxY, rotatedY);
     }
   }
-
-  function updateTraceBounds(edges: any[]) {
-    for (const edge of edges) {
-      minX = Math.min(minX, edge.from.x, edge.to.x);
-      minY = Math.min(minY, edge.from.y, edge.to.y);
-      maxX = Math.max(maxX, edge.from.x, edge.to.x);
-      maxY = Math.max(maxY, edge.from.y, edge.to.y);
-    }
-  }
-
-  function updateTextBounds(position: { x: number; y: number }) {
-    minX = Math.min(minX, position.x);
-    minY = Math.min(minY, position.y);
-    maxX = Math.max(maxX, position.x);
-    maxY = Math.max(maxY, position.y);
-  }
 }
 
-function createSchematicComponent(component: any): string {
-  const { center, size, rotation } = component;
-  const transform = `translate(${center.x}, ${center.y}) rotate(${
-    (rotation * 180) / Math.PI
-  })`;
-  const pinSize = 0.2; // Size of the square pins
+function createSchematicComponent(center: {x: number, y: number}, size: {width: number, height: number}, rotation: number): string {
+  const transform = `translate(${center.x}, ${center.y}) rotate(${(rotation * 180) / Math.PI})`;
 
   return `
-      <g transform="${transform}">
-        <rect 
-          class="component" 
-          x="${-size.width / 2}" 
-          y="${-size.height / 2}" 
-          width="${size.width}" 
-          height="${size.height}" 
-        />
-        <rect 
-        class="component-pin"
-          x="${-size.width / 2 - pinSize / 2}" 
-          y="${-pinSize / 2}" 
-          width="${pinSize}" 
-          height="${pinSize}" 
-        />
-        <rect 
-          class="component-pin"
-          x="${size.width / 2 - pinSize / 2}" 
-          y="${-pinSize / 2}" 
-          width="${pinSize}" 
-          height="${pinSize}" 
-        />
-      </g>
-    `;
+    <g transform="${transform}">
+      <rect 
+        class="component" 
+        x="${-size.width / 2}" 
+        y="${-size.height / 2}" 
+        width="${size.width}" 
+        height="${size.height}" 
+      />
+    </g>
+  `;
 }
 
-function createSchematicTrace(trace: any): string {
+function createSchematicPort(center: {x: number, y: number}): string {
+  const portSize = 0.2;
+  const x = center.x - portSize / 2;
+  const y = center.y - portSize / 2;
+
+  return `
+    <rect 
+      class="port" 
+      x="${x}" 
+      y="${y}" 
+      width="${portSize}" 
+      height="${portSize}" 
+    />
+  `;
+}
+
+function createSchematicTrace(trace: any, flipY: (y: number) => number, portPositions: Map<string, {x: number, y: number}>): string {
   const path = trace.edges.map((edge: any, index: number) => {
-    const fromPoint = `${edge.from.x} ${edge.from.y}`;
-    const toPoint = `${edge.to.x} ${edge.to.y}`;
+    const fromPoint = portPositions.get(edge.from.ti) || { x: edge.from.x, y: flipY(edge.from.y) };
+    const toPoint = portPositions.get(edge.to.ti) || { x: edge.to.x, y: flipY(edge.to.y) };
+    
+    const fromCoord = `${fromPoint.x} ${fromPoint.y}`;
+    const toCoord = `${toPoint.x} ${toPoint.y}`;
     
     if (index === 0) {
-      return `M ${fromPoint} L ${toPoint}`;
+      return `M ${fromCoord} L ${toCoord}`;
     }
-      // Check if this is a 90-degree turn
-      const prevEdge = trace.edges[index - 1];
-      if (prevEdge.to.x === edge.from.x && prevEdge.to.y === edge.from.y) {
-        return `L ${toPoint}`;
-      }
-        // Insert a move command for discontinuous segments
-        return `M ${fromPoint} L ${toPoint}`;
+    // Check if this is a 90-degree turn
+    const prevEdge = trace.edges[index - 1];
+    const prevToPoint = portPositions.get(prevEdge.to.ti) || { x: prevEdge.to.x, y: flipY(prevEdge.to.y) };
+    if (prevToPoint.x === fromPoint.x && prevToPoint.y === fromPoint.y) {
+      return `L ${toCoord}`;
+    }
+    // Insert a move command for discontinuous segments
+    return `M ${fromCoord} L ${toCoord}`;
   }).join(' ');
 
   return `<path class="trace" d="${path}" />`;
 }
 
-function createSchematicText(text: any): string {
+function createSchematicText(text: any, position: {x: number, y: number}): string {
   return `
-      <text 
-        class="text" 
-        x="${text.position.x}" 
-        y="${text.position.y}" 
-        text-anchor="${getTextAnchor(text.anchor)}"
-      >${text.text}</text>
-    `;
+    <text 
+      class="text" 
+      x="${position.x}" 
+      y="${position.y}" 
+      text-anchor="${getTextAnchor(text.anchor)}"
+      dominant-baseline="middle"
+    >${text.text ? text.text : ""}</text>
+  `;
 }
 
-function createSchematicNetLabel(label: any): string {
+function createSchematicNetLabel(label: any, center: {x: number, y: number}): string {
   const width = label.text.length * 0.15 + 0.3;
   const height = 0.3;
   const arrowTip = 0.15;
   const isLeftAnchor = label.anchor_side === "left";
 
-  // Move the entire label to the left
-  const labelCenterX = isLeftAnchor ? label.center.x - width / 3 - 0.2 : label.center.x;
+  const labelCenterX = isLeftAnchor ? center.x - width / 3 - 0.2 : center.x;
 
   const path = isLeftAnchor
     ? `
-      M ${labelCenterX + width},${label.center.y - height / 2}
-      L ${labelCenterX + arrowTip},${label.center.y - height / 2}
-      L ${labelCenterX},${label.center.y}
-      L ${labelCenterX + arrowTip},${label.center.y + height / 2}
-      L ${labelCenterX + width},${label.center.y + height / 2}
+      M ${labelCenterX + width},${center.y - height / 2}
+      L ${labelCenterX + arrowTip},${center.y - height / 2}
+      L ${labelCenterX},${center.y}
+      L ${labelCenterX + arrowTip},${center.y + height / 2}
+      L ${labelCenterX + width},${center.y + height / 2}
       Z
     `
     : `
-      M ${labelCenterX},${label.center.y - height / 2}
-      L ${labelCenterX + width - arrowTip},${label.center.y - height / 2}
-      L ${labelCenterX + width},${label.center.y}
-      L ${labelCenterX + width - arrowTip},${label.center.y + height / 2}
-      L ${labelCenterX},${label.center.y + height / 2}
+      M ${labelCenterX},${center.y - height / 2}
+      L ${labelCenterX + width - arrowTip},${center.y - height / 2}
+      L ${labelCenterX + width},${center.y}
+      L ${labelCenterX + width - arrowTip},${center.y + height / 2}
+      L ${labelCenterX},${center.y + height / 2}
       Z
     `;
 
-  // Keep text centered within the label
   const textX = labelCenterX + width / 2;
 
-  // Add a line to connect the label to the resistor
   const connectingLine = `
     <line 
       x1="${labelCenterX + width}" 
-      y1="${label.center.y}" 
-      x2="${label.center.x}" 
-      y2="${label.center.y}" 
+      y1="${center.y}" 
+      x2="${center.x}" 
+      y2="${center.y}" 
       stroke="green" 
       stroke-width="0.05"
     />
@@ -224,9 +208,9 @@ function createSchematicNetLabel(label: any): string {
       <path d="${path}" fill="white" stroke="black" stroke-width="0.02"/>
       <text 
         x="${textX}" 
-        y="${label.center.y}" 
+        y="${center.y}" 
         text-anchor="middle" 
-        dominant-baseline="central"
+        dominant-baseline="middle"
         fill="black"
       >${label.text}</text>
     </g>

--- a/src/lib/soup-to-svg.ts
+++ b/src/lib/soup-to-svg.ts
@@ -6,36 +6,59 @@ function soupToSvg(soup: AnySoupElement[]): string {
   let maxX = Number.NEGATIVE_INFINITY;
   let maxY = Number.NEGATIVE_INFINITY;
 
-  // First pass: find the bounds
+  const portSize = 0.2;
+  const portPositions = new Map();
+
+  // First pass: find the bounds and collect port positions
   for (const item of soup) {
-    if ('center' in item) {
-      updateBounds(item.center, item.size || {width: 0.2, height: 0.2}, item.rotation || 0);
-    } else if ('position' in item) {
-      updateBounds(item.position, {width: 0, height: 0}, 0);
+    if (item.type === "schematic_component") {
+      updateBounds(item.center, item.size, item.rotation || 0);
+    } else if (item.type === "schematic_port") {
+      updateBounds(item.center, { width: portSize, height: portSize }, 0);
+      portPositions.set(item.schematic_port_id, item.center);
+    } else if (item.type === "schematic_text") {
+      updateBounds(item.position, { width: 0, height: 0 }, 0);
     }
   }
 
   const height = maxY - minY;
-
-  // Function to flip y-coordinate
   const flipY = (y: number) => height - (y - minY) + minY;
 
   const svgContent: string[] = [];
 
-  // Process ports
-  const portPositions = new Map();
+  // Process components
+  const componentMap = new Map();
+  for (const component of soup.filter(
+    (item) => item.type === "schematic_component"
+  )) {
+    const flippedCenter = {
+      x: component.center.x,
+      y: flipY(component.center.y),
+    };
+    const svg = createSchematicComponent(
+      flippedCenter,
+      component.size,
+      component.rotation || 0
+    );
+    svgContent.push(svg);
+    componentMap.set(component.schematic_component_id, component);
+  }
+
+  // Process ports and add lines to component edges
   for (const port of soup.filter((item) => item.type === "schematic_port")) {
     const flippedCenter = { x: port.center.x, y: flipY(port.center.y) };
     const svg = createSchematicPort(flippedCenter);
     svgContent.push(svg);
-    portPositions.set(port.schematic_port_id, flippedCenter);
-  }
 
-  // Process components
-  for (const component of soup.filter((item) => item.type === "schematic_component")) {
-    const flippedCenter = { x: component.center.x, y: flipY(component.center.y) };
-    const svg = createSchematicComponent(flippedCenter, component.size, -component.rotation);
-    svgContent.push(svg);
+    const component = componentMap.get(port.schematic_component_id);
+    if (component) {
+      const line = createPortToComponentLine(
+        flippedCenter,
+        component,
+        port.facing_direction
+      );
+      svgContent.push(line);
+    }
   }
 
   // Process schematic traces
@@ -51,13 +74,6 @@ function soupToSvg(soup: AnySoupElement[]): string {
     svgContent.push(svg);
   }
 
-  // Process net labels
-  for (const label of soup.filter((item) => item.type === "schematic_net_label")) {
-    const flippedCenter = { x: label.center.x, y: flipY(label.center.y) };
-    const svg = createSchematicNetLabel(label, flippedCenter);
-    svgContent.push(svg);
-  }
-
   const padding = 1;
   const width = maxX - minX + 2 * padding;
   const viewBox = `${minX - padding} ${minY - padding} ${width} ${height + 2 * padding}`;
@@ -66,10 +82,9 @@ function soupToSvg(soup: AnySoupElement[]): string {
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="${viewBox}" width="1200" height="600">
       <style>
         .component { fill: none; stroke: red; stroke-width: 0.03; }
-        .component-pin { fill: none; stroke: blue; stroke-width: 0.05; }
+        .component-pin { fill: none; stroke: red; stroke-width: 0.03; }
         .trace { stroke: green; stroke-width: 0.03; fill: none; }
         .text { font-family: Arial, sans-serif; font-size: 0.2px; }
-        .net-label { font-family: Arial, sans-serif; font-size: 0.2px; fill: gray; }
         .port { fill: none; stroke: blue; stroke-width: 0.03; }
       </style>
       ${svgContent.join("\n")}
@@ -85,8 +100,14 @@ function soupToSvg(soup: AnySoupElement[]): string {
     ];
 
     for (const corner of corners) {
-      const rotatedX = corner.x * Math.cos(rotation) - corner.y * Math.sin(rotation) + center.x;
-      const rotatedY = corner.x * Math.sin(rotation) + corner.y * Math.cos(rotation) + center.y;
+      const rotatedX =
+        corner.x * Math.cos(rotation) -
+        corner.y * Math.sin(rotation) +
+        center.x;
+      const rotatedY =
+        corner.x * Math.sin(rotation) +
+        corner.y * Math.cos(rotation) +
+        center.y;
       minX = Math.min(minX, rotatedX);
       minY = Math.min(minY, rotatedY);
       maxX = Math.max(maxX, rotatedX);
@@ -95,7 +116,11 @@ function soupToSvg(soup: AnySoupElement[]): string {
   }
 }
 
-function createSchematicComponent(center: {x: number, y: number}, size: {width: number, height: number}, rotation: number): string {
+function createSchematicComponent(
+  center: { x: number; y: number },
+  size: { width: number; height: number },
+  rotation: number
+): string {
   const transform = `translate(${center.x}, ${center.y}) rotate(${(rotation * 180) / Math.PI})`;
 
   return `
@@ -111,7 +136,7 @@ function createSchematicComponent(center: {x: number, y: number}, size: {width: 
   `;
 }
 
-function createSchematicPort(center: {x: number, y: number}): string {
+function createSchematicPort(center: { x: number; y: number }): string {
   const portSize = 0.2;
   const x = center.x - portSize / 2;
   const y = center.y - portSize / 2;
@@ -127,31 +152,83 @@ function createSchematicPort(center: {x: number, y: number}): string {
   `;
 }
 
-function createSchematicTrace(trace: any, flipY: (y: number) => number, portPositions: Map<string, {x: number, y: number}>): string {
-  const path = trace.edges.map((edge: any, index: number) => {
-    const fromPoint = portPositions.get(edge.from.ti) || { x: edge.from.x, y: flipY(edge.from.y) };
-    const toPoint = portPositions.get(edge.to.ti) || { x: edge.to.x, y: flipY(edge.to.y) };
-    
-    const fromCoord = `${fromPoint.x} ${fromPoint.y}`;
-    const toCoord = `${toPoint.x} ${toPoint.y}`;
-    
-    if (index === 0) {
-      return `M ${fromCoord} L ${toCoord}`;
-    }
-    // Check if this is a 90-degree turn
-    const prevEdge = trace.edges[index - 1];
-    const prevToPoint = portPositions.get(prevEdge.to.ti) || { x: prevEdge.to.x, y: flipY(prevEdge.to.y) };
-    if (prevToPoint.x === fromPoint.x && prevToPoint.y === fromPoint.y) {
-      return `L ${toCoord}`;
-    }
-    // Insert a move command for discontinuous segments
-    return `M ${fromCoord} L ${toCoord}`;
-  }).join(' ');
+function createPortToComponentLine(
+  portCenter: { x: number; y: number },
+  component: any,
+  facingDirection: string
+): string {
+  const componentCenter = { x: component.center.x, y: portCenter.y };
+  const halfWidth = component.size.width / 2;
+  const halfHeight = component.size.height / 2;
 
-  return `<path class="trace" d="${path}" />`;
+  let endX = portCenter.x;
+  let endY = portCenter.y;
+
+  switch (facingDirection) {
+    case "left":
+      endX = componentCenter.x - halfWidth;
+      break;
+    case "right":
+      endX = componentCenter.x + halfWidth;
+      break;
+    case "up":
+      endY = componentCenter.y - halfHeight;
+      break;
+    case "down":
+      endY = componentCenter.y + halfHeight;
+      break;
+  }
+
+  return `
+    <line 
+      class="component-pin"
+      x1="${portCenter.x}" 
+      y1="${portCenter.y}" 
+      x2="${endX}" 
+      y2="${endY}"
+    />
+  `;
 }
 
-function createSchematicText(text: any, position: {x: number, y: number}): string {
+function createSchematicTrace(
+  trace: any,
+  flipY: (y: number) => number,
+  portPositions: Map<string, { x: number; y: number }>
+): string {
+  const path = trace.edges
+    .map((edge: any, index: number) => {
+      const fromPoint =
+        edge.from.ti !== undefined
+          ? portPositions.get(edge.from.ti)
+          : edge.from;
+      const toPoint =
+        edge.to.ti !== undefined ? portPositions.get(edge.to.ti) : edge.to;
+
+      if (!fromPoint || !toPoint) return "";
+
+      const fromCoord = `${fromPoint.x} ${flipY(fromPoint.y)}`;
+      const toCoord = `${toPoint.x} ${flipY(toPoint.y)}`;
+
+      console.log(`Edge ${index}: From ${fromCoord} to ${toCoord}`);
+
+      // If this is a connection to a port, extend the line slightly
+      const extendedToCoord =
+        edge.to.ti !== undefined ? `${toPoint.x} ${flipY(toPoint.y)}` : toCoord;
+
+      return index === 0
+        ? `M ${fromCoord} L ${extendedToCoord}`
+        : `L ${extendedToCoord}`;
+    })
+    .filter((segment: string) => segment !== "")
+    .join(" ");
+
+  return path ? `<path class="trace" d="${path}" />` : "";
+}
+
+function createSchematicText(
+  text: any,
+  position: { x: number; y: number }
+): string {
   return `
     <text 
       class="text" 
@@ -160,60 +237,6 @@ function createSchematicText(text: any, position: {x: number, y: number}): strin
       text-anchor="${getTextAnchor(text.anchor)}"
       dominant-baseline="middle"
     >${text.text ? text.text : ""}</text>
-  `;
-}
-
-function createSchematicNetLabel(label: any, center: {x: number, y: number}): string {
-  const width = label.text.length * 0.15 + 0.3;
-  const height = 0.3;
-  const arrowTip = 0.15;
-  const isLeftAnchor = label.anchor_side === "left";
-
-  const labelCenterX = isLeftAnchor ? center.x - width / 3 - 0.2 : center.x;
-
-  const path = isLeftAnchor
-    ? `
-      M ${labelCenterX + width},${center.y - height / 2}
-      L ${labelCenterX + arrowTip},${center.y - height / 2}
-      L ${labelCenterX},${center.y}
-      L ${labelCenterX + arrowTip},${center.y + height / 2}
-      L ${labelCenterX + width},${center.y + height / 2}
-      Z
-    `
-    : `
-      M ${labelCenterX},${center.y - height / 2}
-      L ${labelCenterX + width - arrowTip},${center.y - height / 2}
-      L ${labelCenterX + width},${center.y}
-      L ${labelCenterX + width - arrowTip},${center.y + height / 2}
-      L ${labelCenterX},${center.y + height / 2}
-      Z
-    `;
-
-  const textX = labelCenterX + width / 2;
-
-  const connectingLine = `
-    <line 
-      x1="${labelCenterX + width}" 
-      y1="${center.y}" 
-      x2="${center.x}" 
-      y2="${center.y}" 
-      stroke="green" 
-      stroke-width="0.05"
-    />
-  `;
-
-  return `
-    <g class="net-label">
-      ${connectingLine}
-      <path d="${path}" fill="white" stroke="black" stroke-width="0.02"/>
-      <text 
-        x="${textX}" 
-        y="${center.y}" 
-        text-anchor="middle" 
-        dominant-baseline="middle"
-        fill="black"
-      >${label.text}</text>
-    </g>
   `;
 }
 

--- a/src/lib/soup-to-svg.ts
+++ b/src/lib/soup-to-svg.ts
@@ -195,32 +195,49 @@ function createSchematicTrace(
   flipY: (y: number) => number,
   portPositions: Map<string, { x: number; y: number }>
 ): string {
-  const path = trace.edges
-    .map((edge: any, index: number) => {
-      const fromPoint =
-        edge.from.ti !== undefined
-          ? portPositions.get(edge.from.ti)
-          : edge.from;
-      const toPoint =
-        edge.to.ti !== undefined ? portPositions.get(edge.to.ti) : edge.to;
+  const edges = trace.edges;
+  if (edges.length === 0) return "";
 
-      if (!fromPoint || !toPoint) return "";
+  let path = "";
 
-      const fromCoord = `${fromPoint.x} ${flipY(fromPoint.y)}`;
-      const toCoord = `${toPoint.x} ${flipY(toPoint.y)}`;
+  // Process all edges
+  edges.forEach((edge: any, index: number) => {
+    const fromPoint =
+      edge.from.ti !== undefined ? portPositions.get(edge.from.ti) : edge.from;
+    const toPoint =
+      edge.to.ti !== undefined ? portPositions.get(edge.to.ti) : edge.to;
 
-      console.log(`Edge ${index}: From ${fromCoord} to ${toCoord}`);
+    if (!fromPoint || !toPoint) {
+      return;
+    }
 
-      // If this is a connection to a port, extend the line slightly
-      const extendedToCoord =
-        edge.to.ti !== undefined ? `${toPoint.x} ${flipY(toPoint.y)}` : toCoord;
+    const fromCoord = `${fromPoint.x} ${flipY(fromPoint.y)}`;
+    const toCoord = `${toPoint.x} ${flipY(toPoint.y)}`;
 
-      return index === 0
-        ? `M ${fromCoord} L ${extendedToCoord}`
-        : `L ${extendedToCoord}`;
-    })
-    .filter((segment: string) => segment !== "")
-    .join(" ");
+    if (index === 0) {
+      path += `M ${fromCoord} L ${toCoord}`;
+    } else {
+      path += ` L ${toCoord}`;
+    }
+  });
+
+  // Handle connection to final port if needed
+  if (trace.to_schematic_port_id) {
+    const finalPort = portPositions.get(trace.to_schematic_port_id);
+    if (finalPort) {
+      const lastFromPoint = path.split("M")[1]?.split("L")[0];
+      console.log(`Last from coord: ${lastFromPoint}`);
+      const lastEdge = edges[edges.length - 1];
+      const lastPoint =
+        lastEdge.to.ti !== undefined
+          ? portPositions.get(lastEdge.to.ti)
+          : lastEdge.to;
+      if (lastPoint.x !== finalPort.x || lastPoint.y !== finalPort.y) {
+        const finalCoord = `${finalPort.x} ${flipY(finalPort.y)}`;
+        path += ` M ${lastFromPoint} L ${finalCoord}`;
+      }
+    }
+  }
 
   return path ? `<path class="trace" d="${path}" />` : "";
 }

--- a/src/stories/net-label-not-overlap.stories.tsx
+++ b/src/stories/net-label-not-overlap.stories.tsx
@@ -1,9 +1,9 @@
 import React from "react";
-import { pcbSoupToSvg } from "../lib/pcb-soup-to-svg.js";
+import { pcbSoupToSvg, soupToSvg } from "../lib/index.js";
 import soup from "../utils/soup.json";
 
 export const NetLabelNotOverlap = () => {
-  const svg = pcbSoupToSvg(soup);
+  const svg = soupToSvg(soup);
 
   return (
     <div

--- a/src/utils/soup.json
+++ b/src/utils/soup.json
@@ -1051,7 +1051,9 @@
           "y": 0
         }
       }
-    ]
+    ],
+    "from_schematic_port_id": "schematic_port_8",
+    "to_schematic_port_id": "schematic_port_0"
   },
   {
     "type": "pcb_trace",

--- a/src/utils/soup.json
+++ b/src/utils/soup.json
@@ -1,7444 +1,1205 @@
 [
-    {
-      "type": "source_component",
-      "source_component_id": "generic_0",
-      "name": "MountingHole",
-      "supplier_part_numbers": {}
-    },
-    {
-      "type": "schematic_component",
-      "schematic_component_id": "schematic_generic_component_0",
-      "source_component_id": "generic_0",
-      "center": {
-        "x": 0,
-        "y": 0
-      },
-      "rotation": 0,
-      "size": {
-        "width": 0,
-        "height": 0
-      }
-    },
-    {
-      "type": "pcb_component",
-      "source_component_id": "generic_0",
-      "pcb_component_id": "pcb_generic_component_0",
-      "layer": "top",
-      "center": {
-        "x": 0,
-        "y": 0
-      },
-      "rotation": 0,
-      "width": 3.200000000000001,
-      "height": 3.200000000000001
-    },
-    {
-      "type": "pcb_plated_hole",
-      "x": -10,
-      "y": 10,
-      "layers": [
-        "top",
-        "bottom"
-      ],
-      "hole_diameter": 2.5,
-      "shape": "circle",
-      "outer_diameter": 3.2,
-      "port_hints": [
-        "1"
-      ],
-      "pcb_component_id": "pcb_generic_component_0"
-    },
-    {
-      "type": "source_component",
-      "source_component_id": "generic_1",
-      "name": "MountingHole",
-      "supplier_part_numbers": {}
-    },
-    {
-      "type": "schematic_component",
-      "schematic_component_id": "schematic_generic_component_1",
-      "source_component_id": "generic_1",
-      "center": {
-        "x": 0,
-        "y": 0
-      },
-      "rotation": 0,
-      "size": {
-        "width": 0,
-        "height": 0
-      }
-    },
-    {
-      "type": "pcb_component",
-      "source_component_id": "generic_1",
-      "pcb_component_id": "pcb_generic_component_1",
-      "layer": "top",
-      "center": {
-        "x": 0,
-        "y": 0
-      },
-      "rotation": 0,
-      "width": 3.200000000000001,
-      "height": 3.200000000000001
-    },
-    {
-      "type": "pcb_plated_hole",
-      "x": -10,
-      "y": -10,
-      "layers": [
-        "top",
-        "bottom"
-      ],
-      "hole_diameter": 2.5,
-      "shape": "circle",
-      "outer_diameter": 3.2,
-      "port_hints": [
-        "1"
-      ],
-      "pcb_component_id": "pcb_generic_component_1"
-    },
-    {
-      "type": "source_component",
-      "source_component_id": "simple_bug_0",
-      "name": "U1",
-      "supplier_part_numbers": {},
-      "ftype": "simple_bug",
-      "pcbRotation": "90deg",
-      "pinLabels": {
-        "1": "AOUT1_1",
-        "2": "AOUT1_2",
-        "3": "PGND1_1",
-        "4": "PGND1_2",
-        "5": "AOUT2_1",
-        "6": "AOUT2_2",
-        "7": "BOUT2_1",
-        "8": "BOUT2_2",
-        "9": "PGND2_1",
-        "10": "PGND2_2",
-        "11": "BOUT1_1",
-        "12": "BOUT1_2",
-        "13": "VM2",
-        "14": "VM3",
-        "15": "PWMB",
-        "16": "BIN2",
-        "17": "BIN1",
-        "18": "GND",
-        "19": "STBY",
-        "20": "VCC",
-        "21": "AIN1",
-        "22": "AIN2",
-        "23": "PWMA",
-        "24": "VM1"
-      },
-      "schPinSpacing": 0.75,
-      "schWidth": 2,
-      "schPortArrangement": {
-        "leftSide": {
-          "direction": "top-to-bottom",
-          "pins": [
-            20,
-            21,
-            22,
-            23,
-            19,
-            17,
-            16,
-            15,
-            18
-          ]
-        },
-        "rightSide": {
-          "direction": "bottom-to-top",
-          "pins": [
-            10,
-            9,
-            8,
-            7,
-            12,
-            11,
-            14,
-            13,
-            4,
-            3,
-            6,
-            5,
-            2,
-            1,
-            24
-          ]
-        },
-        "left_side": {
-          "direction": "top-to-bottom",
-          "pins": [
-            20,
-            21,
-            22,
-            23,
-            19,
-            17,
-            16,
-            15,
-            18
-          ]
-        },
-        "right_side": {
-          "direction": "bottom-to-top",
-          "pins": [
-            10,
-            9,
-            8,
-            7,
-            12,
-            11,
-            14,
-            13,
-            4,
-            3,
-            6,
-            5,
-            2,
-            1,
-            24
-          ]
-        }
-      },
-      "cad_model": {
-        "rotationOffset": 90,
-        "objUrl": "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=47443b588a77418ba6b4ea51975c36c0&pn=C88224",
-        "rotation_offset": 90,
-        "obj_url": "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=47443b588a77418ba6b4ea51975c36c0&pn=C88224"
-      },
-      "pin_labels": {
-        "1": "AOUT1_1",
-        "2": "AOUT1_2",
-        "3": "PGND1_1",
-        "4": "PGND1_2",
-        "5": "AOUT2_1",
-        "6": "AOUT2_2",
-        "7": "BOUT2_1",
-        "8": "BOUT2_2",
-        "9": "PGND2_1",
-        "10": "PGND2_2",
-        "11": "BOUT1_1",
-        "12": "BOUT1_2",
-        "13": "VM2",
-        "14": "VM3",
-        "15": "PWMB",
-        "16": "BIN2",
-        "17": "BIN1",
-        "18": "GND",
-        "19": "STBY",
-        "20": "VCC",
-        "21": "AIN1",
-        "22": "AIN2",
-        "23": "PWMA",
-        "24": "VM1"
-      },
-      "sch_pin_spacing": 0.75,
-      "sch_width": 2,
-      "sch_port_arrangement": {
-        "leftSide": {
-          "direction": "top-to-bottom",
-          "pins": [
-            20,
-            21,
-            22,
-            23,
-            19,
-            17,
-            16,
-            15,
-            18
-          ]
-        },
-        "rightSide": {
-          "direction": "bottom-to-top",
-          "pins": [
-            10,
-            9,
-            8,
-            7,
-            12,
-            11,
-            14,
-            13,
-            4,
-            3,
-            6,
-            5,
-            2,
-            1,
-            24
-          ]
-        },
-        "left_side": {
-          "direction": "top-to-bottom",
-          "pins": [
-            20,
-            21,
-            22,
-            23,
-            19,
-            17,
-            16,
-            15,
-            18
-          ]
-        },
-        "right_side": {
-          "direction": "bottom-to-top",
-          "pins": [
-            10,
-            9,
-            8,
-            7,
-            12,
-            11,
-            14,
-            13,
-            4,
-            3,
-            6,
-            5,
-            2,
-            1,
-            24
-          ]
-        }
-      }
-    },
-    {
-      "type": "schematic_component",
-      "source_component_id": "simple_bug_0",
-      "schematic_component_id": "schematic_component_simple_bug_0",
-      "rotation": 0,
-      "size": {
-        "width": 1.5,
-        "height": 11.25
-      },
-      "center": {
-        "x": 0,
-        "y": 0
-      },
-      "port_labels": {
-        "1": "AOUT1_1",
-        "2": "AOUT1_2",
-        "3": "PGND1_1",
-        "4": "PGND1_2",
-        "5": "AOUT2_1",
-        "6": "AOUT2_2",
-        "7": "BOUT2_1",
-        "8": "BOUT2_2",
-        "9": "PGND2_1",
-        "10": "PGND2_2",
-        "11": "BOUT1_1",
-        "12": "BOUT1_2",
-        "13": "VM2",
-        "14": "VM3",
-        "15": "PWMB",
-        "16": "BIN2",
-        "17": "BIN1",
-        "18": "GND",
-        "19": "STBY",
-        "20": "VCC",
-        "21": "AIN1",
-        "22": "AIN2",
-        "23": "PWMA",
-        "24": "VM1"
-      },
-      "port_arrangement": {
-        "left_side": {
-          "direction": "top-to-bottom",
-          "pins": [
-            20,
-            21,
-            22,
-            23,
-            19,
-            17,
-            16,
-            15,
-            18
-          ]
-        },
-        "right_side": {
-          "direction": "bottom-to-top",
-          "pins": [
-            10,
-            9,
-            8,
-            7,
-            12,
-            11,
-            14,
-            13,
-            4,
-            3,
-            6,
-            5,
-            2,
-            1,
-            24
-          ]
-        }
-      },
-      "pin_spacing": 0.75
-    },
-    {
-      "type": "source_port",
-      "name": "VCC",
-      "source_port_id": "source_port_0",
-      "source_component_id": "simple_bug_0",
-      "pin_number": 20,
-      "port_hints": [
-        "VCC",
-        "20"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_0",
-      "source_port_id": "source_port_0",
-      "center": {
-        "x": -1.125,
-        "y": 3
-      },
-      "facing_direction": "left",
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_0",
-      "schematic_text_id": "schematic_text_24",
-      "text": "20",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": -1.0012563132923542,
-        "y": 2.876256313292354
-      },
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_0",
-      "source_port_id": "source_port_0",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "x": 5.236095876782892,
-      "y": 1.4959308303641727,
-      "layers": [
-        "top"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "AIN1",
-      "source_port_id": "source_port_1",
-      "source_component_id": "simple_bug_0",
-      "pin_number": 21,
-      "port_hints": [
-        "AIN1",
-        "21"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_1",
-      "source_port_id": "source_port_1",
-      "center": {
-        "x": -1.125,
-        "y": 2.25
-      },
-      "facing_direction": "left",
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_1",
-      "schematic_text_id": "schematic_text_25",
-      "text": "21",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": -1.0012563132923542,
-        "y": 2.126256313292354
-      },
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_1",
-      "source_port_id": "source_port_1",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "x": 5.236095876782892,
-      "y": 0.8459308303641728,
-      "layers": [
-        "top"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "AIN2",
-      "source_port_id": "source_port_2",
-      "source_component_id": "simple_bug_0",
-      "pin_number": 22,
-      "port_hints": [
-        "AIN2",
-        "22"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_2",
-      "source_port_id": "source_port_2",
-      "center": {
-        "x": -1.125,
-        "y": 1.5
-      },
-      "facing_direction": "left",
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_2",
-      "schematic_text_id": "schematic_text_26",
-      "text": "22",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": -1.0012563132923542,
-        "y": 1.3762563132923542
-      },
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_2",
-      "source_port_id": "source_port_2",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "x": 5.236095876782892,
-      "y": 0.19593083036417314,
-      "layers": [
-        "top"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "PWMA",
-      "source_port_id": "source_port_3",
-      "source_component_id": "simple_bug_0",
-      "pin_number": 23,
-      "port_hints": [
-        "PWMA",
-        "23"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_3",
-      "source_port_id": "source_port_3",
-      "center": {
-        "x": -1.125,
-        "y": 0.75
-      },
-      "facing_direction": "left",
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_3",
-      "schematic_text_id": "schematic_text_27",
-      "text": "23",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": -1.0012563132923542,
-        "y": 0.6262563132923542
-      },
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_3",
-      "source_port_id": "source_port_3",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "x": 5.236095876782892,
-      "y": -0.4540691696358272,
-      "layers": [
-        "top"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "STBY",
-      "source_port_id": "source_port_4",
-      "source_component_id": "simple_bug_0",
-      "pin_number": 19,
-      "port_hints": [
-        "STBY",
-        "19"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_4",
-      "source_port_id": "source_port_4",
-      "center": {
-        "x": -1.125,
-        "y": 0
-      },
-      "facing_direction": "left",
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_4",
-      "schematic_text_id": "schematic_text_28",
-      "text": "19",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": -1.0012563132923542,
-        "y": -0.12374368670764582
-      },
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_4",
-      "source_port_id": "source_port_4",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "x": 5.236095876782892,
-      "y": 2.1559308303641727,
-      "layers": [
-        "top"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "BIN1",
-      "source_port_id": "source_port_5",
-      "source_component_id": "simple_bug_0",
-      "pin_number": 17,
-      "port_hints": [
-        "BIN1",
-        "17"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_5",
-      "source_port_id": "source_port_5",
-      "center": {
-        "x": -1.125,
-        "y": -0.75
-      },
-      "facing_direction": "left",
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_5",
-      "schematic_text_id": "schematic_text_29",
-      "text": "17",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": -1.0012563132923542,
-        "y": -0.8737436867076458
-      },
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_5",
-      "source_port_id": "source_port_5",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "x": 5.236095876782892,
-      "y": 3.4559308303641725,
-      "layers": [
-        "top"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "BIN2",
-      "source_port_id": "source_port_6",
-      "source_component_id": "simple_bug_0",
-      "pin_number": 16,
-      "port_hints": [
-        "BIN2",
-        "16"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_6",
-      "source_port_id": "source_port_6",
-      "center": {
-        "x": -1.125,
-        "y": -1.5
-      },
-      "facing_direction": "left",
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_6",
-      "schematic_text_id": "schematic_text_30",
-      "text": "16",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": -1.0012563132923542,
-        "y": -1.6237436867076458
-      },
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_6",
-      "source_port_id": "source_port_6",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "x": 5.236095876782892,
-      "y": 4.105930830364173,
-      "layers": [
-        "top"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "PWMB",
-      "source_port_id": "source_port_7",
-      "source_component_id": "simple_bug_0",
-      "pin_number": 15,
-      "port_hints": [
-        "PWMB",
-        "15"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_7",
-      "source_port_id": "source_port_7",
-      "center": {
-        "x": -1.125,
-        "y": -2.25
-      },
-      "facing_direction": "left",
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_7",
-      "schematic_text_id": "schematic_text_31",
-      "text": "15",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": -1.0012563132923542,
-        "y": -2.373743686707646
-      },
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_7",
-      "source_port_id": "source_port_7",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "x": 5.236095876782892,
-      "y": 4.755930830364173,
-      "layers": [
-        "top"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "GND",
-      "source_port_id": "source_port_8",
-      "source_component_id": "simple_bug_0",
-      "pin_number": 18,
-      "port_hints": [
-        "GND",
-        "18"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_8",
-      "source_port_id": "source_port_8",
-      "center": {
-        "x": -1.125,
-        "y": -3
-      },
-      "facing_direction": "left",
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_8",
-      "schematic_text_id": "schematic_text_32",
-      "text": "18",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": -1.0012563132923542,
-        "y": -3.123743686707646
-      },
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_8",
-      "source_port_id": "source_port_8",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "x": 5.236095876782892,
-      "y": 2.8059308303641726,
-      "layers": [
-        "top"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "PGND2_2",
-      "source_port_id": "source_port_9",
-      "source_component_id": "simple_bug_0",
-      "pin_number": 10,
-      "port_hints": [
-        "PGND2_2",
-        "10"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_9",
-      "source_port_id": "source_port_9",
-      "center": {
-        "x": 1.125,
-        "y": -5.25
-      },
-      "facing_direction": "right",
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_9",
-      "schematic_text_id": "schematic_text_33",
-      "text": "10",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": 1.0012563132923542,
-        "y": -5.373743686707646
-      },
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_9",
-      "source_port_id": "source_port_9",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "x": -1.7439041232171082,
-      "y": 4.755930830364173,
-      "layers": [
-        "top"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "PGND2_1",
-      "source_port_id": "source_port_10",
-      "source_component_id": "simple_bug_0",
-      "pin_number": 9,
-      "port_hints": [
-        "PGND2_1",
-        "9"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_10",
-      "source_port_id": "source_port_10",
-      "center": {
-        "x": 1.125,
-        "y": -4.5
-      },
-      "facing_direction": "right",
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_10",
-      "schematic_text_id": "schematic_text_34",
-      "text": "9",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": 1.0012563132923542,
-        "y": -4.623743686707646
-      },
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_10",
-      "source_port_id": "source_port_10",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "x": -1.7439041232171082,
-      "y": 4.105930830364173,
-      "layers": [
-        "top"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "BOUT2_2",
-      "source_port_id": "source_port_11",
-      "source_component_id": "simple_bug_0",
-      "pin_number": 8,
-      "port_hints": [
-        "BOUT2_2",
-        "8"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_11",
-      "source_port_id": "source_port_11",
-      "center": {
-        "x": 1.125,
-        "y": -3.75
-      },
-      "facing_direction": "right",
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_11",
-      "schematic_text_id": "schematic_text_35",
-      "text": "8",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": 1.0012563132923542,
-        "y": -3.873743686707646
-      },
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_11",
-      "source_port_id": "source_port_11",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "x": -1.7439041232171082,
-      "y": 3.4559308303641734,
-      "layers": [
-        "top"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "BOUT2_1",
-      "source_port_id": "source_port_12",
-      "source_component_id": "simple_bug_0",
-      "pin_number": 7,
-      "port_hints": [
-        "BOUT2_1",
-        "7"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_12",
-      "source_port_id": "source_port_12",
-      "center": {
-        "x": 1.125,
-        "y": -3
-      },
-      "facing_direction": "right",
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_12",
-      "schematic_text_id": "schematic_text_36",
-      "text": "7",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": 1.0012563132923542,
-        "y": -3.123743686707646
-      },
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_12",
-      "source_port_id": "source_port_12",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "x": -1.7439041232171082,
-      "y": 2.805930830364173,
-      "layers": [
-        "top"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "BOUT1_2",
-      "source_port_id": "source_port_13",
-      "source_component_id": "simple_bug_0",
-      "pin_number": 12,
-      "port_hints": [
-        "BOUT1_2",
-        "12"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_13",
-      "source_port_id": "source_port_13",
-      "center": {
-        "x": 1.125,
-        "y": -2.25
-      },
-      "facing_direction": "right",
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_13",
-      "schematic_text_id": "schematic_text_37",
-      "text": "12",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": 1.0012563132923542,
-        "y": -2.373743686707646
-      },
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_13",
-      "source_port_id": "source_port_13",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "x": -1.7439041232171082,
-      "y": 6.055930830364173,
-      "layers": [
-        "top"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "BOUT1_1",
-      "source_port_id": "source_port_14",
-      "source_component_id": "simple_bug_0",
-      "pin_number": 11,
-      "port_hints": [
-        "BOUT1_1",
-        "11"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_14",
-      "source_port_id": "source_port_14",
-      "center": {
-        "x": 1.125,
-        "y": -1.5
-      },
-      "facing_direction": "right",
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_14",
-      "schematic_text_id": "schematic_text_38",
-      "text": "11",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": 1.0012563132923542,
-        "y": -1.6237436867076458
-      },
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_14",
-      "source_port_id": "source_port_14",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "x": -1.7439041232171082,
-      "y": 5.4059308303641735,
-      "layers": [
-        "top"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "VM3",
-      "source_port_id": "source_port_15",
-      "source_component_id": "simple_bug_0",
-      "pin_number": 14,
-      "port_hints": [
-        "VM3",
-        "14"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_15",
-      "source_port_id": "source_port_15",
-      "center": {
-        "x": 1.125,
-        "y": -0.75
-      },
-      "facing_direction": "right",
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_15",
-      "schematic_text_id": "schematic_text_39",
-      "text": "14",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": 1.0012563132923542,
-        "y": -0.8737436867076458
-      },
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_15",
-      "source_port_id": "source_port_15",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "x": 5.236095876782892,
-      "y": 5.4059308303641735,
-      "layers": [
-        "top"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "VM2",
-      "source_port_id": "source_port_16",
-      "source_component_id": "simple_bug_0",
-      "pin_number": 13,
-      "port_hints": [
-        "VM2",
-        "13"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_16",
-      "source_port_id": "source_port_16",
-      "center": {
-        "x": 1.125,
-        "y": 0
-      },
-      "facing_direction": "right",
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_16",
-      "schematic_text_id": "schematic_text_40",
-      "text": "13",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": 1.0012563132923542,
-        "y": -0.12374368670764582
-      },
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_16",
-      "source_port_id": "source_port_16",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "x": 5.236095876782892,
-      "y": 6.055930830364173,
-      "layers": [
-        "top"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "PGND1_2",
-      "source_port_id": "source_port_17",
-      "source_component_id": "simple_bug_0",
-      "pin_number": 4,
-      "port_hints": [
-        "PGND1_2",
-        "4"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_17",
-      "source_port_id": "source_port_17",
-      "center": {
-        "x": 1.125,
-        "y": 0.75
-      },
-      "facing_direction": "right",
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_17",
-      "schematic_text_id": "schematic_text_41",
-      "text": "4",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": 1.0012563132923542,
-        "y": 0.6262563132923542
-      },
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_17",
-      "source_port_id": "source_port_17",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "x": -1.7439041232171082,
-      "y": 0.8459308303641733,
-      "layers": [
-        "top"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "PGND1_1",
-      "source_port_id": "source_port_18",
-      "source_component_id": "simple_bug_0",
-      "pin_number": 3,
-      "port_hints": [
-        "PGND1_1",
-        "3"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_18",
-      "source_port_id": "source_port_18",
-      "center": {
-        "x": 1.125,
-        "y": 1.5
-      },
-      "facing_direction": "right",
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_18",
-      "schematic_text_id": "schematic_text_42",
-      "text": "3",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": 1.0012563132923542,
-        "y": 1.3762563132923542
-      },
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_18",
-      "source_port_id": "source_port_18",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "x": -1.7439041232171082,
-      "y": 0.19593083036417314,
-      "layers": [
-        "top"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "AOUT2_2",
-      "source_port_id": "source_port_19",
-      "source_component_id": "simple_bug_0",
-      "pin_number": 6,
-      "port_hints": [
-        "AOUT2_2",
-        "6"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_19",
-      "source_port_id": "source_port_19",
-      "center": {
-        "x": 1.125,
-        "y": 2.25
-      },
-      "facing_direction": "right",
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_19",
-      "schematic_text_id": "schematic_text_43",
-      "text": "6",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": 1.0012563132923542,
-        "y": 2.126256313292354
-      },
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_19",
-      "source_port_id": "source_port_19",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "x": -1.7439041232171082,
-      "y": 2.155930830364173,
-      "layers": [
-        "top"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "AOUT2_1",
-      "source_port_id": "source_port_20",
-      "source_component_id": "simple_bug_0",
-      "pin_number": 5,
-      "port_hints": [
-        "AOUT2_1",
-        "5"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_20",
-      "source_port_id": "source_port_20",
-      "center": {
-        "x": 1.125,
-        "y": 3
-      },
-      "facing_direction": "right",
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_20",
-      "schematic_text_id": "schematic_text_44",
-      "text": "5",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": 1.0012563132923542,
-        "y": 2.876256313292354
-      },
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_20",
-      "source_port_id": "source_port_20",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "x": -1.7439041232171082,
-      "y": 1.4959308303641732,
-      "layers": [
-        "top"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "AOUT1_2",
-      "source_port_id": "source_port_21",
-      "source_component_id": "simple_bug_0",
-      "pin_number": 2,
-      "port_hints": [
-        "AOUT1_2",
-        "2"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_21",
-      "source_port_id": "source_port_21",
-      "center": {
-        "x": 1.125,
-        "y": 3.75
-      },
-      "facing_direction": "right",
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_21",
-      "schematic_text_id": "schematic_text_45",
-      "text": "2",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": 1.0012563132923542,
-        "y": 3.626256313292354
-      },
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_21",
-      "source_port_id": "source_port_21",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "x": -1.7439041232171082,
-      "y": -0.4540691696358272,
-      "layers": [
-        "top"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "AOUT1_1",
-      "source_port_id": "source_port_22",
-      "source_component_id": "simple_bug_0",
-      "pin_number": 1,
-      "port_hints": [
-        "AOUT1_1",
-        "1"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_22",
-      "source_port_id": "source_port_22",
-      "center": {
-        "x": 1.125,
-        "y": 4.5
-      },
-      "facing_direction": "right",
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_22",
-      "schematic_text_id": "schematic_text_46",
-      "text": "1",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": 1.0012563132923542,
-        "y": 4.376256313292354
-      },
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_22",
-      "source_port_id": "source_port_22",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "x": -1.7439041232171082,
-      "y": -1.1040691696358271,
-      "layers": [
-        "top"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "VM1",
-      "source_port_id": "source_port_23",
-      "source_component_id": "simple_bug_0",
-      "pin_number": 24,
-      "port_hints": [
-        "VM1",
-        "24"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_23",
-      "source_port_id": "source_port_23",
-      "center": {
-        "x": 1.125,
-        "y": 5.25
-      },
-      "facing_direction": "right",
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_23",
-      "schematic_text_id": "schematic_text_47",
-      "text": "24",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": 1.0012563132923542,
-        "y": 5.126256313292354
-      },
-      "schematic_component_id": "schematic_component_simple_bug_0"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_23",
-      "source_port_id": "source_port_23",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "x": 5.236095876782892,
-      "y": -1.1040691696358271,
-      "layers": [
-        "top"
-      ]
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_0",
-      "schematic_component_id": "schematic_component_simple_bug_0",
-      "text": "VCC",
-      "anchor": "left",
-      "rotation": 0,
-      "position": {
-        "x": -0.5249999999999999,
-        "y": 3
-      }
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_1",
-      "schematic_component_id": "schematic_component_simple_bug_0",
-      "text": "AIN1",
-      "anchor": "left",
-      "rotation": 0,
-      "position": {
-        "x": -0.5249999999999999,
-        "y": 2.25
-      }
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_2",
-      "schematic_component_id": "schematic_component_simple_bug_0",
-      "text": "AIN2",
-      "anchor": "left",
-      "rotation": 0,
-      "position": {
-        "x": -0.5249999999999999,
-        "y": 1.5
-      }
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_3",
-      "schematic_component_id": "schematic_component_simple_bug_0",
-      "text": "PWMA",
-      "anchor": "left",
-      "rotation": 0,
-      "position": {
-        "x": -0.5249999999999999,
-        "y": 0.75
-      }
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_4",
-      "schematic_component_id": "schematic_component_simple_bug_0",
-      "text": "STBY",
-      "anchor": "left",
-      "rotation": 0,
-      "position": {
-        "x": -0.5249999999999999,
-        "y": 0
-      }
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_5",
-      "schematic_component_id": "schematic_component_simple_bug_0",
-      "text": "BIN1",
-      "anchor": "left",
-      "rotation": 0,
-      "position": {
-        "x": -0.5249999999999999,
-        "y": -0.75
-      }
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_6",
-      "schematic_component_id": "schematic_component_simple_bug_0",
-      "text": "BIN2",
-      "anchor": "left",
-      "rotation": 0,
-      "position": {
-        "x": -0.5249999999999999,
-        "y": -1.5
-      }
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_7",
-      "schematic_component_id": "schematic_component_simple_bug_0",
-      "text": "PWMB",
-      "anchor": "left",
-      "rotation": 0,
-      "position": {
-        "x": -0.5249999999999999,
-        "y": -2.25
-      }
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_8",
-      "schematic_component_id": "schematic_component_simple_bug_0",
-      "text": "GND",
-      "anchor": "left",
-      "rotation": 0,
-      "position": {
-        "x": -0.5249999999999999,
-        "y": -3
-      }
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_9",
-      "schematic_component_id": "schematic_component_simple_bug_0",
-      "text": "PGND2_2",
-      "anchor": "right",
-      "rotation": 0,
-      "position": {
-        "x": 0.5249999999999999,
-        "y": -5.25
-      }
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_10",
-      "schematic_component_id": "schematic_component_simple_bug_0",
-      "text": "PGND2_1",
-      "anchor": "right",
-      "rotation": 0,
-      "position": {
-        "x": 0.5249999999999999,
-        "y": -4.5
-      }
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_11",
-      "schematic_component_id": "schematic_component_simple_bug_0",
-      "text": "BOUT2_2",
-      "anchor": "right",
-      "rotation": 0,
-      "position": {
-        "x": 0.5249999999999999,
-        "y": -3.75
-      }
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_12",
-      "schematic_component_id": "schematic_component_simple_bug_0",
-      "text": "BOUT2_1",
-      "anchor": "right",
-      "rotation": 0,
-      "position": {
-        "x": 0.5249999999999999,
-        "y": -3
-      }
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_13",
-      "schematic_component_id": "schematic_component_simple_bug_0",
-      "text": "BOUT1_2",
-      "anchor": "right",
-      "rotation": 0,
-      "position": {
-        "x": 0.5249999999999999,
-        "y": -2.25
-      }
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_14",
-      "schematic_component_id": "schematic_component_simple_bug_0",
-      "text": "BOUT1_1",
-      "anchor": "right",
-      "rotation": 0,
-      "position": {
-        "x": 0.5249999999999999,
-        "y": -1.5
-      }
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_15",
-      "schematic_component_id": "schematic_component_simple_bug_0",
-      "text": "VM3",
-      "anchor": "right",
-      "rotation": 0,
-      "position": {
-        "x": 0.5249999999999999,
-        "y": -0.75
-      }
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_16",
-      "schematic_component_id": "schematic_component_simple_bug_0",
-      "text": "VM2",
-      "anchor": "right",
-      "rotation": 0,
-      "position": {
-        "x": 0.5249999999999999,
-        "y": 0
-      }
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_17",
-      "schematic_component_id": "schematic_component_simple_bug_0",
-      "text": "PGND1_2",
-      "anchor": "right",
-      "rotation": 0,
-      "position": {
-        "x": 0.5249999999999999,
-        "y": 0.75
-      }
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_18",
-      "schematic_component_id": "schematic_component_simple_bug_0",
-      "text": "PGND1_1",
-      "anchor": "right",
-      "rotation": 0,
-      "position": {
-        "x": 0.5249999999999999,
-        "y": 1.5
-      }
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_19",
-      "schematic_component_id": "schematic_component_simple_bug_0",
-      "text": "AOUT2_2",
-      "anchor": "right",
-      "rotation": 0,
-      "position": {
-        "x": 0.5249999999999999,
-        "y": 2.25
-      }
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_20",
-      "schematic_component_id": "schematic_component_simple_bug_0",
-      "text": "AOUT2_1",
-      "anchor": "right",
-      "rotation": 0,
-      "position": {
-        "x": 0.5249999999999999,
-        "y": 3
-      }
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_21",
-      "schematic_component_id": "schematic_component_simple_bug_0",
-      "text": "AOUT1_2",
-      "anchor": "right",
-      "rotation": 0,
-      "position": {
-        "x": 0.5249999999999999,
-        "y": 3.75
-      }
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_22",
-      "schematic_component_id": "schematic_component_simple_bug_0",
-      "text": "AOUT1_1",
-      "anchor": "right",
-      "rotation": 0,
-      "position": {
-        "x": 0.5249999999999999,
-        "y": 4.5
-      }
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_23",
-      "schematic_component_id": "schematic_component_simple_bug_0",
-      "text": "VM1",
-      "anchor": "right",
-      "rotation": 0,
-      "position": {
-        "x": 0.5249999999999999,
-        "y": 5.25
-      }
-    },
-    {
-      "type": "pcb_component",
-      "source_component_id": "simple_bug_0",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "layer": "top",
-      "center": {
-        "x": 1.746095876782892,
-        "y": 2.475930830364173
-      },
-      "rotation": 1.5707963267948966,
-      "width": 9.062012533375599,
-      "height": 7.524007388351763
-    },
-    {
-      "type": "pcb_smtpad",
-      "pcb_smtpad_id": "pcb_smtpad_2",
-      "shape": "rect",
-      "x": -1.7439041232171082,
-      "y": -1.1040691696358271,
-      "width": 2.0820125333755986,
-      "height": 0.36400738835176355,
-      "layer": "top",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "port_hints": [
-        "1"
-      ],
-      "pcb_port_id": "pcb_port_22"
-    },
-    {
-      "type": "pcb_smtpad",
-      "pcb_smtpad_id": "pcb_smtpad_9",
-      "shape": "rect",
-      "x": -1.7439041232171082,
-      "y": -0.4540691696358272,
-      "width": 2.0820125333755986,
-      "height": 0.36400738835176355,
-      "layer": "top",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "port_hints": [
-        "2"
-      ],
-      "pcb_port_id": "pcb_port_21"
-    },
-    {
-      "type": "pcb_smtpad",
-      "pcb_smtpad_id": "pcb_smtpad_15",
-      "shape": "rect",
-      "x": -1.7439041232171082,
-      "y": 0.19593083036417314,
-      "width": 2.0820125333755986,
-      "height": 0.36400738835176355,
-      "layer": "top",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "port_hints": [
-        "3"
-      ],
-      "pcb_port_id": "pcb_port_18"
-    },
-    {
-      "type": "pcb_smtpad",
-      "pcb_smtpad_id": "pcb_smtpad_18",
-      "shape": "rect",
-      "x": -1.7439041232171082,
-      "y": 0.8459308303641733,
-      "width": 2.0820125333755986,
-      "height": 0.36400738835176355,
-      "layer": "top",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "port_hints": [
-        "4"
-      ],
-      "pcb_port_id": "pcb_port_17"
-    },
-    {
-      "type": "pcb_smtpad",
-      "pcb_smtpad_id": "pcb_smtpad_20",
-      "shape": "rect",
-      "x": -1.7439041232171082,
-      "y": 1.4959308303641732,
-      "width": 2.0820125333755986,
-      "height": 0.36400738835176355,
-      "layer": "top",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "port_hints": [
-        "5"
-      ],
-      "pcb_port_id": "pcb_port_20"
-    },
-    {
-      "type": "pcb_smtpad",
-      "pcb_smtpad_id": "pcb_smtpad_22",
-      "shape": "rect",
-      "x": -1.7439041232171082,
-      "y": 2.155930830364173,
-      "width": 2.0820125333755986,
-      "height": 0.36400738835176355,
-      "layer": "top",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "port_hints": [
-        "6"
-      ],
-      "pcb_port_id": "pcb_port_19"
-    },
-    {
-      "type": "pcb_smtpad",
-      "pcb_smtpad_id": "pcb_smtpad_24",
-      "shape": "rect",
-      "x": -1.7439041232171082,
-      "y": 2.805930830364173,
-      "width": 2.0820125333755986,
-      "height": 0.36400738835176355,
-      "layer": "top",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "port_hints": [
-        "7"
-      ],
-      "pcb_port_id": "pcb_port_12"
-    },
-    {
-      "type": "pcb_smtpad",
-      "pcb_smtpad_id": "pcb_smtpad_26",
-      "shape": "rect",
-      "x": -1.7439041232171082,
-      "y": 3.4559308303641734,
-      "width": 2.0820125333755986,
-      "height": 0.36400738835176355,
-      "layer": "top",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "port_hints": [
-        "8"
-      ],
-      "pcb_port_id": "pcb_port_11"
-    },
-    {
-      "type": "pcb_smtpad",
-      "pcb_smtpad_id": "pcb_smtpad_28",
-      "shape": "rect",
-      "x": -1.7439041232171082,
-      "y": 4.105930830364173,
-      "width": 2.0820125333755986,
-      "height": 0.36400738835176355,
-      "layer": "top",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "port_hints": [
-        "9"
-      ],
-      "pcb_port_id": "pcb_port_10"
-    },
-    {
-      "type": "pcb_smtpad",
-      "pcb_smtpad_id": "pcb_smtpad_30",
-      "shape": "rect",
-      "x": -1.7439041232171082,
-      "y": 4.755930830364173,
-      "width": 2.0820125333755986,
-      "height": 0.36400738835176355,
-      "layer": "top",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "port_hints": [
-        "10"
-      ],
-      "pcb_port_id": "pcb_port_9"
-    },
-    {
-      "type": "pcb_smtpad",
-      "pcb_smtpad_id": "pcb_smtpad_32",
-      "shape": "rect",
-      "x": -1.7439041232171082,
-      "y": 5.4059308303641735,
-      "width": 2.0820125333755986,
-      "height": 0.36400738835176355,
-      "layer": "top",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "port_hints": [
-        "11"
-      ],
-      "pcb_port_id": "pcb_port_14"
-    },
-    {
-      "type": "pcb_smtpad",
-      "pcb_smtpad_id": "pcb_smtpad_34",
-      "shape": "rect",
-      "x": -1.7439041232171082,
-      "y": 6.055930830364173,
-      "width": 2.0820125333755986,
-      "height": 0.36400738835176355,
-      "layer": "top",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "port_hints": [
-        "12"
-      ],
-      "pcb_port_id": "pcb_port_13"
-    },
-    {
-      "type": "pcb_smtpad",
-      "pcb_smtpad_id": "pcb_smtpad_36",
-      "shape": "rect",
-      "x": 5.236095876782892,
-      "y": -1.1040691696358271,
-      "width": 2.0820125333755986,
-      "height": 0.36400738835176355,
-      "layer": "top",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "port_hints": [
-        "24"
-      ],
-      "pcb_port_id": "pcb_port_23"
-    },
-    {
-      "type": "pcb_smtpad",
-      "pcb_smtpad_id": "pcb_smtpad_38",
-      "shape": "rect",
-      "x": 5.236095876782892,
-      "y": -0.4540691696358272,
-      "width": 2.0820125333755986,
-      "height": 0.36400738835176355,
-      "layer": "top",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "port_hints": [
-        "23"
-      ],
-      "pcb_port_id": "pcb_port_3"
-    },
-    {
-      "type": "pcb_smtpad",
-      "pcb_smtpad_id": "pcb_smtpad_40",
-      "shape": "rect",
-      "x": 5.236095876782892,
-      "y": 0.19593083036417314,
-      "width": 2.0820125333755986,
-      "height": 0.36400738835176355,
-      "layer": "top",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "port_hints": [
-        "22"
-      ],
-      "pcb_port_id": "pcb_port_2"
-    },
-    {
-      "type": "pcb_smtpad",
-      "pcb_smtpad_id": "pcb_smtpad_42",
-      "shape": "rect",
-      "x": 5.236095876782892,
-      "y": 0.8459308303641728,
-      "width": 2.0820125333755986,
-      "height": 0.36400738835176355,
-      "layer": "top",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "port_hints": [
-        "21"
-      ],
-      "pcb_port_id": "pcb_port_1"
-    },
-    {
-      "type": "pcb_smtpad",
-      "pcb_smtpad_id": "pcb_smtpad_44",
-      "shape": "rect",
-      "x": 5.236095876782892,
-      "y": 1.4959308303641727,
-      "width": 2.0820125333755986,
-      "height": 0.36400738835176355,
-      "layer": "top",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "port_hints": [
-        "20"
-      ],
-      "pcb_port_id": "pcb_port_0"
-    },
-    {
-      "type": "pcb_smtpad",
-      "pcb_smtpad_id": "pcb_smtpad_46",
-      "shape": "rect",
-      "x": 5.236095876782892,
-      "y": 2.1559308303641727,
-      "width": 2.0820125333755986,
-      "height": 0.36400738835176355,
-      "layer": "top",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "port_hints": [
-        "19"
-      ],
-      "pcb_port_id": "pcb_port_4"
-    },
-    {
-      "type": "pcb_smtpad",
-      "pcb_smtpad_id": "pcb_smtpad_48",
-      "shape": "rect",
-      "x": 5.236095876782892,
-      "y": 2.8059308303641726,
-      "width": 2.0820125333755986,
-      "height": 0.36400738835176355,
-      "layer": "top",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "port_hints": [
-        "18"
-      ],
-      "pcb_port_id": "pcb_port_8"
-    },
-    {
-      "type": "pcb_smtpad",
-      "pcb_smtpad_id": "pcb_smtpad_50",
-      "shape": "rect",
-      "x": 5.236095876782892,
-      "y": 3.4559308303641725,
-      "width": 2.0820125333755986,
-      "height": 0.36400738835176355,
-      "layer": "top",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "port_hints": [
-        "17"
-      ],
-      "pcb_port_id": "pcb_port_5"
-    },
-    {
-      "type": "pcb_smtpad",
-      "pcb_smtpad_id": "pcb_smtpad_52",
-      "shape": "rect",
-      "x": 5.236095876782892,
-      "y": 4.105930830364173,
-      "width": 2.0820125333755986,
-      "height": 0.36400738835176355,
-      "layer": "top",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "port_hints": [
-        "16"
-      ],
-      "pcb_port_id": "pcb_port_6"
-    },
-    {
-      "type": "pcb_smtpad",
-      "pcb_smtpad_id": "pcb_smtpad_54",
-      "shape": "rect",
-      "x": 5.236095876782892,
-      "y": 4.755930830364173,
-      "width": 2.0820125333755986,
-      "height": 0.36400738835176355,
-      "layer": "top",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "port_hints": [
-        "15"
-      ],
-      "pcb_port_id": "pcb_port_7"
-    },
-    {
-      "type": "pcb_smtpad",
-      "pcb_smtpad_id": "pcb_smtpad_56",
-      "shape": "rect",
-      "x": 5.236095876782892,
-      "y": 5.4059308303641735,
-      "width": 2.0820125333755986,
-      "height": 0.36400738835176355,
-      "layer": "top",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "port_hints": [
-        "14"
-      ],
-      "pcb_port_id": "pcb_port_15"
-    },
-    {
-      "type": "pcb_smtpad",
-      "pcb_smtpad_id": "pcb_smtpad_57",
-      "shape": "rect",
-      "x": 5.236095876782892,
-      "y": 6.055930830364173,
-      "width": 2.0820125333755986,
-      "height": 0.36400738835176355,
-      "layer": "top",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "port_hints": [
-        "13"
-      ],
-      "pcb_port_id": "pcb_port_16"
-    },
-    {
-      "type": "cad_component",
-      "cad_component_id": "cad_component_1",
-      "source_component_id": "simple_bug_0",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "position": {
-        "x": 1.746095876782892,
-        "y": 2.475930830364173,
-        "z": 0.6
-      },
-      "rotation": {
-        "x": 0,
-        "y": 0,
-        "z": 180
-      },
-      "layer": "top",
-      "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=47443b588a77418ba6b4ea51975c36c0&pn=C88224"
-    },
-    {
-      "type": "source_component",
-      "source_component_id": "simple_bug_1",
-      "name": "J1",
-      "supplier_part_numbers": {},
-      "ftype": "simple_bug",
-      "pinLabels": {
-        "1": "PWRIN",
-        "2": "GND"
-      },
-      "schX": -12,
-      "schY": -2,
-      "schPortArrangement": {
-        "rightSide": {
-          "direction": "top-to-bottom",
-          "pins": [
-            2,
-            1
-          ]
-        },
-        "right_side": {
-          "direction": "top-to-bottom",
-          "pins": [
-            2,
-            1
-          ]
-        }
-      },
-      "pin_labels": {
-        "1": "PWRIN",
-        "2": "GND"
-      },
-      "sch_port_arrangement": {
-        "rightSide": {
-          "direction": "top-to-bottom",
-          "pins": [
-            2,
-            1
-          ]
-        },
-        "right_side": {
-          "direction": "top-to-bottom",
-          "pins": [
-            2,
-            1
-          ]
-        }
-      }
-    },
-    {
-      "type": "schematic_component",
-      "source_component_id": "simple_bug_1",
-      "schematic_component_id": "schematic_component_simple_bug_1",
-      "rotation": 0,
-      "size": {
-        "width": 1,
-        "height": 1
-      },
-      "center": {
-        "x": -12,
-        "y": -2
-      },
-      "port_labels": {
-        "1": "PWRIN",
-        "2": "GND"
-      },
-      "port_arrangement": {
-        "right_side": {
-          "direction": "top-to-bottom",
-          "pins": [
-            2,
-            1
-          ]
-        }
-      }
-    },
-    {
-      "type": "source_port",
-      "name": "GND",
-      "source_port_id": "source_port_24",
-      "source_component_id": "simple_bug_1",
-      "pin_number": 2,
-      "port_hints": [
-        "GND",
-        "2"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_24",
-      "source_port_id": "source_port_24",
-      "center": {
-        "x": -11.25,
-        "y": -2.25
-      },
-      "facing_direction": "right",
-      "schematic_component_id": "schematic_component_simple_bug_1"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_24",
-      "schematic_text_id": "schematic_text_50",
-      "text": "2",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": -11.373743686707646,
-        "y": -2.3737436867076456
-      },
-      "schematic_component_id": "schematic_component_simple_bug_1"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_24",
-      "source_port_id": "source_port_24",
-      "pcb_component_id": "pcb_component_simple_bug_1",
-      "x": 2.850393383627095,
-      "y": -10.745920624907164,
-      "layers": [
-        "top",
-        "bottom"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "PWRIN",
-      "source_port_id": "source_port_25",
-      "source_component_id": "simple_bug_1",
-      "pin_number": 1,
-      "port_hints": [
-        "PWRIN",
-        "1"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_25",
-      "source_port_id": "source_port_25",
-      "center": {
-        "x": -11.25,
-        "y": -1.75
-      },
-      "facing_direction": "right",
-      "schematic_component_id": "schematic_component_simple_bug_1"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_25",
-      "schematic_text_id": "schematic_text_51",
-      "text": "1",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": -11.373743686707646,
-        "y": -1.8737436867076458
-      },
-      "schematic_component_id": "schematic_component_simple_bug_1"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_25",
-      "source_port_id": "source_port_25",
-      "pcb_component_id": "pcb_component_simple_bug_1",
-      "x": 0.3103934649070921,
-      "y": -10.745920624907164,
-      "layers": [
-        "top",
-        "bottom"
-      ]
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_48",
-      "schematic_component_id": "schematic_component_simple_bug_1",
-      "text": "GND",
-      "anchor": "right",
-      "rotation": 0,
-      "position": {
-        "x": -11.65,
-        "y": -2.25
-      }
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_49",
-      "schematic_component_id": "schematic_component_simple_bug_1",
-      "text": "PWRIN",
-      "anchor": "right",
-      "rotation": 0,
-      "position": {
-        "x": -11.65,
-        "y": -1.75
-      }
-    },
-    {
-      "type": "pcb_component",
-      "source_component_id": "simple_bug_1",
-      "pcb_component_id": "pcb_component_simple_bug_1",
-      "layer": "top",
-      "center": {
-        "x": 1.5803934242670934,
-        "y": -10.745920624907164
-      },
-      "rotation": 0,
-      "width": 3.7399999187200024,
-      "height": 1.2
-    },
-    {
-      "type": "pcb_plated_hole",
-      "x": 0.3103934649070921,
-      "y": -10.745920624907164,
-      "layers": [
-        "top",
-        "bottom"
-      ],
-      "hole_diameter": 1,
-      "shape": "circle",
-      "outer_diameter": 1.2,
-      "port_hints": [
-        "1"
-      ],
-      "pcb_component_id": "pcb_component_simple_bug_1",
-      "pcb_port_id": "pcb_port_25"
-    },
-    {
-      "type": "pcb_plated_hole",
-      "x": 2.850393383627095,
-      "y": -10.745920624907164,
-      "layers": [
-        "top",
-        "bottom"
-      ],
-      "hole_diameter": 1,
-      "shape": "circle",
-      "outer_diameter": 1.2,
-      "port_hints": [
-        "2"
-      ],
-      "pcb_component_id": "pcb_component_simple_bug_1",
-      "pcb_port_id": "pcb_port_24"
-    },
-    {
-      "type": "source_component",
-      "source_component_id": "simple_bug_2",
-      "name": "JP1",
-      "supplier_part_numbers": {},
-      "ftype": "simple_bug",
-      "pcbRotation": "90deg",
-      "pinLabels": {
-        "1": "PWRIN",
-        "2": "VCC",
-        "3": "PWMB",
-        "5": "BIN2",
-        "6": "BIN1",
-        "7": "STBY",
-        "8": "AIN1",
-        "9": "AIN2",
-        "10": "PWMA"
-      },
-      "schPortArrangement": {
-        "rightSize": 10,
-        "right_size": 10
-      },
-      "schX": -12,
-      "schY": 4,
-      "pin_labels": {
-        "1": "PWRIN",
-        "2": "VCC",
-        "3": "PWMB",
-        "5": "BIN2",
-        "6": "BIN1",
-        "7": "STBY",
-        "8": "AIN1",
-        "9": "AIN2",
-        "10": "PWMA"
-      },
-      "sch_port_arrangement": {
-        "rightSize": 10,
-        "right_size": 10
-      }
-    },
-    {
-      "type": "schematic_component",
-      "source_component_id": "simple_bug_2",
-      "schematic_component_id": "schematic_component_simple_bug_2",
-      "rotation": 0,
-      "size": {
-        "width": 1,
-        "height": 5
-      },
-      "center": {
-        "x": -12,
-        "y": 4
-      },
-      "port_labels": {
-        "1": "PWRIN",
-        "2": "VCC",
-        "3": "PWMB",
-        "5": "BIN2",
-        "6": "BIN1",
-        "7": "STBY",
-        "8": "AIN1",
-        "9": "AIN2",
-        "10": "PWMA"
-      },
-      "port_arrangement": {
-        "right_size": 10
-      }
-    },
-    {
-      "type": "source_port",
-      "name": "PWRIN",
-      "source_port_id": "source_port_26",
-      "source_component_id": "simple_bug_2",
-      "pin_number": 1,
-      "port_hints": [
-        "PWRIN",
-        "1"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_26",
-      "source_port_id": "source_port_26",
-      "center": {
-        "x": -11.25,
-        "y": 1.75
-      },
-      "facing_direction": "right",
-      "schematic_component_id": "schematic_component_simple_bug_2"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_26",
-      "schematic_text_id": "schematic_text_62",
-      "text": "1",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": -11.373743686707646,
-        "y": 1.626256313292354
-      },
-      "schematic_component_id": "schematic_component_simple_bug_2"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_26",
-      "source_port_id": "source_port_26",
-      "pcb_component_id": "pcb_component_simple_bug_2",
-      "x": 14.285834859193642,
-      "y": -12.49212545618126,
-      "layers": [
-        "top",
-        "bottom"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "VCC",
-      "source_port_id": "source_port_27",
-      "source_component_id": "simple_bug_2",
-      "pin_number": 2,
-      "port_hints": [
-        "VCC",
-        "2"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_27",
-      "source_port_id": "source_port_27",
-      "center": {
-        "x": -11.25,
-        "y": 2.25
-      },
-      "facing_direction": "right",
-      "schematic_component_id": "schematic_component_simple_bug_2"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_27",
-      "schematic_text_id": "schematic_text_63",
-      "text": "2",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": -11.373743686707646,
-        "y": 2.1262563132923544
-      },
-      "schematic_component_id": "schematic_component_simple_bug_2"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_27",
-      "source_port_id": "source_port_27",
-      "pcb_component_id": "pcb_component_simple_bug_2",
-      "x": 14.285834859193642,
-      "y": -9.952125537461256,
-      "layers": [
-        "top",
-        "bottom"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "PWMB",
-      "source_port_id": "source_port_28",
-      "source_component_id": "simple_bug_2",
-      "pin_number": 3,
-      "port_hints": [
-        "PWMB",
-        "3"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_28",
-      "source_port_id": "source_port_28",
-      "center": {
-        "x": -11.25,
-        "y": 2.75
-      },
-      "facing_direction": "right",
-      "schematic_component_id": "schematic_component_simple_bug_2"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_28",
-      "schematic_text_id": "schematic_text_64",
-      "text": "3",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": -11.373743686707646,
-        "y": 2.6262563132923544
-      },
-      "schematic_component_id": "schematic_component_simple_bug_2"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_28",
-      "source_port_id": "source_port_28",
-      "pcb_component_id": "pcb_component_simple_bug_2",
-      "x": 14.285834859193642,
-      "y": -7.412125618741254,
-      "layers": [
-        "top",
-        "bottom"
-      ]
-    },
-    {
-      "type": "source_port",
-      "source_port_id": "source_port_29",
-      "source_component_id": "simple_bug_2",
-      "pin_number": 4,
-      "port_hints": [
-        "4"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_29",
-      "source_port_id": "source_port_29",
-      "center": {
-        "x": -11.25,
-        "y": 3.25
-      },
-      "facing_direction": "right",
-      "schematic_component_id": "schematic_component_simple_bug_2"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_29",
-      "schematic_text_id": "schematic_text_65",
-      "text": "4",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": -11.373743686707646,
-        "y": 3.1262563132923544
-      },
-      "schematic_component_id": "schematic_component_simple_bug_2"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_29",
-      "source_port_id": "source_port_29",
-      "pcb_component_id": "pcb_component_simple_bug_2",
-      "x": 14.285834859193642,
-      "y": -4.872125700021252,
-      "layers": [
-        "top",
-        "bottom"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "BIN2",
-      "source_port_id": "source_port_30",
-      "source_component_id": "simple_bug_2",
-      "pin_number": 5,
-      "port_hints": [
-        "BIN2",
-        "5"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_30",
-      "source_port_id": "source_port_30",
-      "center": {
-        "x": -11.25,
-        "y": 3.75
-      },
-      "facing_direction": "right",
-      "schematic_component_id": "schematic_component_simple_bug_2"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_30",
-      "schematic_text_id": "schematic_text_66",
-      "text": "5",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": -11.373743686707646,
-        "y": 3.6262563132923544
-      },
-      "schematic_component_id": "schematic_component_simple_bug_2"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_30",
-      "source_port_id": "source_port_30",
-      "pcb_component_id": "pcb_component_simple_bug_2",
-      "x": 14.285834859193642,
-      "y": -2.332125781301249,
-      "layers": [
-        "top",
-        "bottom"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "BIN1",
-      "source_port_id": "source_port_31",
-      "source_component_id": "simple_bug_2",
-      "pin_number": 6,
-      "port_hints": [
-        "BIN1",
-        "6"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_31",
-      "source_port_id": "source_port_31",
-      "center": {
-        "x": -11.25,
-        "y": 4.25
-      },
-      "facing_direction": "right",
-      "schematic_component_id": "schematic_component_simple_bug_2"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_31",
-      "schematic_text_id": "schematic_text_67",
-      "text": "6",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": -11.373743686707646,
-        "y": 4.126256313292354
-      },
-      "schematic_component_id": "schematic_component_simple_bug_2"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_31",
-      "source_port_id": "source_port_31",
-      "pcb_component_id": "pcb_component_simple_bug_2",
-      "x": 14.285834859193642,
-      "y": 0.20787413741875405,
-      "layers": [
-        "top",
-        "bottom"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "STBY",
-      "source_port_id": "source_port_32",
-      "source_component_id": "simple_bug_2",
-      "pin_number": 7,
-      "port_hints": [
-        "STBY",
-        "7"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_32",
-      "source_port_id": "source_port_32",
-      "center": {
-        "x": -11.25,
-        "y": 4.75
-      },
-      "facing_direction": "right",
-      "schematic_component_id": "schematic_component_simple_bug_2"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_32",
-      "schematic_text_id": "schematic_text_68",
-      "text": "7",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": -11.373743686707646,
-        "y": 4.626256313292354
-      },
-      "schematic_component_id": "schematic_component_simple_bug_2"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_32",
-      "source_port_id": "source_port_32",
-      "pcb_component_id": "pcb_component_simple_bug_2",
-      "x": 14.285834859193642,
-      "y": 2.7478740561387553,
-      "layers": [
-        "top",
-        "bottom"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "AIN1",
-      "source_port_id": "source_port_33",
-      "source_component_id": "simple_bug_2",
-      "pin_number": 8,
-      "port_hints": [
-        "AIN1",
-        "8"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_33",
-      "source_port_id": "source_port_33",
-      "center": {
-        "x": -11.25,
-        "y": 5.25
-      },
-      "facing_direction": "right",
-      "schematic_component_id": "schematic_component_simple_bug_2"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_33",
-      "schematic_text_id": "schematic_text_69",
-      "text": "8",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": -11.373743686707646,
-        "y": 5.126256313292354
-      },
-      "schematic_component_id": "schematic_component_simple_bug_2"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_33",
-      "source_port_id": "source_port_33",
-      "pcb_component_id": "pcb_component_simple_bug_2",
-      "x": 14.285834859193642,
-      "y": 5.287873974858758,
-      "layers": [
-        "top",
-        "bottom"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "AIN2",
-      "source_port_id": "source_port_34",
-      "source_component_id": "simple_bug_2",
-      "pin_number": 9,
-      "port_hints": [
-        "AIN2",
-        "9"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_34",
-      "source_port_id": "source_port_34",
-      "center": {
-        "x": -11.25,
-        "y": 5.75
-      },
-      "facing_direction": "right",
-      "schematic_component_id": "schematic_component_simple_bug_2"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_34",
-      "schematic_text_id": "schematic_text_70",
-      "text": "9",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": -11.373743686707646,
-        "y": 5.626256313292354
-      },
-      "schematic_component_id": "schematic_component_simple_bug_2"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_34",
-      "source_port_id": "source_port_34",
-      "pcb_component_id": "pcb_component_simple_bug_2",
-      "x": 14.285834859193642,
-      "y": 7.8278738935787615,
-      "layers": [
-        "top",
-        "bottom"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "PWMA",
-      "source_port_id": "source_port_35",
-      "source_component_id": "simple_bug_2",
-      "pin_number": 10,
-      "port_hints": [
-        "PWMA",
-        "10"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_35",
-      "source_port_id": "source_port_35",
-      "center": {
-        "x": -11.25,
-        "y": 6.25
-      },
-      "facing_direction": "right",
-      "schematic_component_id": "schematic_component_simple_bug_2"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_35",
-      "schematic_text_id": "schematic_text_71",
-      "text": "10",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": -11.373743686707646,
-        "y": 6.1262563132923535
-      },
-      "schematic_component_id": "schematic_component_simple_bug_2"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_35",
-      "source_port_id": "source_port_35",
-      "pcb_component_id": "pcb_component_simple_bug_2",
-      "x": 14.285834859193642,
-      "y": 10.367873812298765,
-      "layers": [
-        "top",
-        "bottom"
-      ]
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_52",
-      "schematic_component_id": "schematic_component_simple_bug_2",
-      "text": "PWRIN",
-      "anchor": "right",
-      "rotation": 0,
-      "position": {
-        "x": -11.65,
-        "y": 1.75
-      }
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_53",
-      "schematic_component_id": "schematic_component_simple_bug_2",
-      "text": "VCC",
-      "anchor": "right",
-      "rotation": 0,
-      "position": {
-        "x": -11.65,
-        "y": 2.25
-      }
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_54",
-      "schematic_component_id": "schematic_component_simple_bug_2",
-      "text": "PWMB",
-      "anchor": "right",
-      "rotation": 0,
-      "position": {
-        "x": -11.65,
-        "y": 2.75
-      }
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_55",
-      "schematic_component_id": "schematic_component_simple_bug_2",
-      "anchor": "right",
-      "rotation": 0,
-      "position": {
-        "x": -11.65,
-        "y": 3.25
-      }
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_56",
-      "schematic_component_id": "schematic_component_simple_bug_2",
-      "text": "BIN2",
-      "anchor": "right",
-      "rotation": 0,
-      "position": {
-        "x": -11.65,
-        "y": 3.75
-      }
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_57",
-      "schematic_component_id": "schematic_component_simple_bug_2",
-      "text": "BIN1",
-      "anchor": "right",
-      "rotation": 0,
-      "position": {
-        "x": -11.65,
-        "y": 4.25
-      }
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_58",
-      "schematic_component_id": "schematic_component_simple_bug_2",
-      "text": "STBY",
-      "anchor": "right",
-      "rotation": 0,
-      "position": {
-        "x": -11.65,
-        "y": 4.75
-      }
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_59",
-      "schematic_component_id": "schematic_component_simple_bug_2",
-      "text": "AIN1",
-      "anchor": "right",
-      "rotation": 0,
-      "position": {
-        "x": -11.65,
-        "y": 5.25
-      }
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_60",
-      "schematic_component_id": "schematic_component_simple_bug_2",
-      "text": "AIN2",
-      "anchor": "right",
-      "rotation": 0,
-      "position": {
-        "x": -11.65,
-        "y": 5.75
-      }
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_61",
-      "schematic_component_id": "schematic_component_simple_bug_2",
-      "text": "PWMA",
-      "anchor": "right",
-      "rotation": 0,
-      "position": {
-        "x": -11.65,
-        "y": 6.25
-      }
-    },
-    {
-      "type": "pcb_component",
-      "source_component_id": "simple_bug_2",
-      "pcb_component_id": "pcb_component_simple_bug_2",
-      "layer": "top",
-      "center": {
-        "x": 14.285834859193642,
-        "y": -1.0621258219412475
-      },
-      "rotation": 1.5707963267948966,
-      "width": 1.2000000000000013,
-      "height": 24.059999268480023
-    },
-    {
-      "type": "pcb_plated_hole",
-      "x": 14.285834859193642,
-      "y": -12.49212545618126,
-      "layers": [
-        "top",
-        "bottom"
-      ],
-      "hole_diameter": 1,
-      "shape": "circle",
-      "outer_diameter": 1.2,
-      "port_hints": [
-        "1"
-      ],
-      "pcb_component_id": "pcb_component_simple_bug_2",
-      "pcb_port_id": "pcb_port_26"
-    },
-    {
-      "type": "pcb_plated_hole",
-      "x": 14.285834859193642,
-      "y": -9.952125537461256,
-      "layers": [
-        "top",
-        "bottom"
-      ],
-      "hole_diameter": 1,
-      "shape": "circle",
-      "outer_diameter": 1.2,
-      "port_hints": [
-        "2"
-      ],
-      "pcb_component_id": "pcb_component_simple_bug_2",
-      "pcb_port_id": "pcb_port_27"
-    },
-    {
-      "type": "pcb_plated_hole",
-      "x": 14.285834859193642,
-      "y": -7.412125618741254,
-      "layers": [
-        "top",
-        "bottom"
-      ],
-      "hole_diameter": 1,
-      "shape": "circle",
-      "outer_diameter": 1.2,
-      "port_hints": [
-        "3"
-      ],
-      "pcb_component_id": "pcb_component_simple_bug_2",
-      "pcb_port_id": "pcb_port_28"
-    },
-    {
-      "type": "pcb_plated_hole",
-      "x": 14.285834859193642,
-      "y": -4.872125700021252,
-      "layers": [
-        "top",
-        "bottom"
-      ],
-      "hole_diameter": 1,
-      "shape": "circle",
-      "outer_diameter": 1.2,
-      "port_hints": [
-        "4"
-      ],
-      "pcb_component_id": "pcb_component_simple_bug_2",
-      "pcb_port_id": "pcb_port_29"
-    },
-    {
-      "type": "pcb_plated_hole",
-      "x": 14.285834859193642,
-      "y": -2.332125781301249,
-      "layers": [
-        "top",
-        "bottom"
-      ],
-      "hole_diameter": 1,
-      "shape": "circle",
-      "outer_diameter": 1.2,
-      "port_hints": [
-        "5"
-      ],
-      "pcb_component_id": "pcb_component_simple_bug_2",
-      "pcb_port_id": "pcb_port_30"
-    },
-    {
-      "type": "pcb_plated_hole",
-      "x": 14.285834859193642,
-      "y": 0.20787413741875405,
-      "layers": [
-        "top",
-        "bottom"
-      ],
-      "hole_diameter": 1,
-      "shape": "circle",
-      "outer_diameter": 1.2,
-      "port_hints": [
-        "6"
-      ],
-      "pcb_component_id": "pcb_component_simple_bug_2",
-      "pcb_port_id": "pcb_port_31"
-    },
-    {
-      "type": "pcb_plated_hole",
-      "x": 14.285834859193642,
-      "y": 2.7478740561387553,
-      "layers": [
-        "top",
-        "bottom"
-      ],
-      "hole_diameter": 1,
-      "shape": "circle",
-      "outer_diameter": 1.2,
-      "port_hints": [
-        "7"
-      ],
-      "pcb_component_id": "pcb_component_simple_bug_2",
-      "pcb_port_id": "pcb_port_32"
-    },
-    {
-      "type": "pcb_plated_hole",
-      "x": 14.285834859193642,
-      "y": 5.287873974858758,
-      "layers": [
-        "top",
-        "bottom"
-      ],
-      "hole_diameter": 1,
-      "shape": "circle",
-      "outer_diameter": 1.2,
-      "port_hints": [
-        "8"
-      ],
-      "pcb_component_id": "pcb_component_simple_bug_2",
-      "pcb_port_id": "pcb_port_33"
-    },
-    {
-      "type": "pcb_plated_hole",
-      "x": 14.285834859193642,
-      "y": 7.8278738935787615,
-      "layers": [
-        "top",
-        "bottom"
-      ],
-      "hole_diameter": 1,
-      "shape": "circle",
-      "outer_diameter": 1.2,
-      "port_hints": [
-        "9"
-      ],
-      "pcb_component_id": "pcb_component_simple_bug_2",
-      "pcb_port_id": "pcb_port_34"
-    },
-    {
-      "type": "pcb_plated_hole",
-      "x": 14.285834859193642,
-      "y": 10.367873812298765,
-      "layers": [
-        "top",
-        "bottom"
-      ],
-      "hole_diameter": 1,
-      "shape": "circle",
-      "outer_diameter": 1.2,
-      "port_hints": [
-        "10"
-      ],
-      "pcb_component_id": "pcb_component_simple_bug_2",
-      "pcb_port_id": "pcb_port_35"
-    },
-    {
-      "type": "source_component",
-      "source_component_id": "simple_bug_3",
-      "name": "JP3",
-      "supplier_part_numbers": {},
-      "ftype": "simple_bug",
-      "pinLabels": {
-        "1": "MA1",
-        "2": "MA2",
-        "3": "GND",
-        "4": "MB2",
-        "5": "MB1"
-      },
-      "schX": 5,
-      "schY": 0,
-      "schPortArrangement": {
-        "leftSize": 5,
-        "left_size": 5
-      },
-      "pcbRotation": "90deg",
-      "pin_labels": {
-        "1": "MA1",
-        "2": "MA2",
-        "3": "GND",
-        "4": "MB2",
-        "5": "MB1"
-      },
-      "sch_port_arrangement": {
-        "leftSize": 5,
-        "left_size": 5
-      }
-    },
-    {
-      "type": "schematic_component",
-      "source_component_id": "simple_bug_3",
-      "schematic_component_id": "schematic_component_simple_bug_3",
-      "rotation": 0,
-      "size": {
-        "width": 1,
-        "height": 2.5
-      },
-      "center": {
-        "x": 5,
-        "y": 0
-      },
-      "port_labels": {
-        "1": "MA1",
-        "2": "MA2",
-        "3": "GND",
-        "4": "MB2",
-        "5": "MB1"
-      },
-      "port_arrangement": {
-        "left_size": 5
-      }
-    },
-    {
-      "type": "source_port",
-      "name": "MA1",
-      "source_port_id": "source_port_36",
-      "source_component_id": "simple_bug_3",
-      "pin_number": 1,
-      "port_hints": [
-        "MA1",
-        "1"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_36",
-      "source_port_id": "source_port_36",
-      "center": {
-        "x": 4.25,
-        "y": 1
-      },
-      "facing_direction": "left",
-      "schematic_component_id": "schematic_component_simple_bug_3"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_36",
-      "schematic_text_id": "schematic_text_77",
-      "text": "1",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": 4.373743686707646,
-        "y": 0.8762563132923542
-      },
-      "schematic_component_id": "schematic_component_simple_bug_3"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_36",
-      "source_port_id": "source_port_36",
-      "pcb_component_id": "pcb_component_simple_bug_3",
-      "x": -10.015882522757462,
-      "y": -5.372549330856729,
-      "layers": [
-        "top",
-        "bottom"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "MA2",
-      "source_port_id": "source_port_37",
-      "source_component_id": "simple_bug_3",
-      "pin_number": 2,
-      "port_hints": [
-        "MA2",
-        "2"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_37",
-      "source_port_id": "source_port_37",
-      "center": {
-        "x": 4.25,
-        "y": 0.5
-      },
-      "facing_direction": "left",
-      "schematic_component_id": "schematic_component_simple_bug_3"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_37",
-      "schematic_text_id": "schematic_text_78",
-      "text": "2",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": 4.373743686707646,
-        "y": 0.3762563132923542
-      },
-      "schematic_component_id": "schematic_component_simple_bug_3"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_37",
-      "source_port_id": "source_port_37",
-      "pcb_component_id": "pcb_component_simple_bug_3",
-      "x": -10.015882522757462,
-      "y": -2.8325494121367263,
-      "layers": [
-        "top",
-        "bottom"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "GND",
-      "source_port_id": "source_port_38",
-      "source_component_id": "simple_bug_3",
-      "pin_number": 3,
-      "port_hints": [
-        "GND",
-        "3"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_38",
-      "source_port_id": "source_port_38",
-      "center": {
-        "x": 4.25,
-        "y": 0
-      },
-      "facing_direction": "left",
-      "schematic_component_id": "schematic_component_simple_bug_3"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_38",
-      "schematic_text_id": "schematic_text_79",
-      "text": "3",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": 4.373743686707646,
-        "y": -0.12374368670764582
-      },
-      "schematic_component_id": "schematic_component_simple_bug_3"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_38",
-      "source_port_id": "source_port_38",
-      "pcb_component_id": "pcb_component_simple_bug_3",
-      "x": -10.015882522757462,
-      "y": -0.29254949341672365,
-      "layers": [
-        "top",
-        "bottom"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "MB2",
-      "source_port_id": "source_port_39",
-      "source_component_id": "simple_bug_3",
-      "pin_number": 4,
-      "port_hints": [
-        "MB2",
-        "4"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_39",
-      "source_port_id": "source_port_39",
-      "center": {
-        "x": 4.25,
-        "y": -0.5
-      },
-      "facing_direction": "left",
-      "schematic_component_id": "schematic_component_simple_bug_3"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_39",
-      "schematic_text_id": "schematic_text_80",
-      "text": "4",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": 4.373743686707646,
-        "y": -0.6237436867076458
-      },
-      "schematic_component_id": "schematic_component_simple_bug_3"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_39",
-      "source_port_id": "source_port_39",
-      "pcb_component_id": "pcb_component_simple_bug_3",
-      "x": -10.015882522757462,
-      "y": 2.2474504253032785,
-      "layers": [
-        "top",
-        "bottom"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "MB1",
-      "source_port_id": "source_port_40",
-      "source_component_id": "simple_bug_3",
-      "pin_number": 5,
-      "port_hints": [
-        "MB1",
-        "5"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_40",
-      "source_port_id": "source_port_40",
-      "center": {
-        "x": 4.25,
-        "y": -1
-      },
-      "facing_direction": "left",
-      "schematic_component_id": "schematic_component_simple_bug_3"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_40",
-      "schematic_text_id": "schematic_text_81",
-      "text": "5",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": 4.373743686707646,
-        "y": -1.1237436867076458
-      },
-      "schematic_component_id": "schematic_component_simple_bug_3"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_40",
-      "source_port_id": "source_port_40",
-      "pcb_component_id": "pcb_component_simple_bug_3",
-      "x": -10.015882522757462,
-      "y": 4.787450344023282,
-      "layers": [
-        "top",
-        "bottom"
-      ]
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_72",
-      "schematic_component_id": "schematic_component_simple_bug_3",
-      "text": "MA1",
-      "anchor": "left",
-      "rotation": 0,
-      "position": {
-        "x": 4.65,
-        "y": 1
-      }
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_73",
-      "schematic_component_id": "schematic_component_simple_bug_3",
-      "text": "MA2",
-      "anchor": "left",
-      "rotation": 0,
-      "position": {
-        "x": 4.65,
-        "y": 0.5
-      }
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_74",
-      "schematic_component_id": "schematic_component_simple_bug_3",
-      "text": "GND",
-      "anchor": "left",
-      "rotation": 0,
-      "position": {
-        "x": 4.65,
-        "y": 0
-      }
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_75",
-      "schematic_component_id": "schematic_component_simple_bug_3",
-      "text": "MB2",
-      "anchor": "left",
-      "rotation": 0,
-      "position": {
-        "x": 4.65,
-        "y": -0.5
-      }
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_76",
-      "schematic_component_id": "schematic_component_simple_bug_3",
-      "text": "MB1",
-      "anchor": "left",
-      "rotation": 0,
-      "position": {
-        "x": 4.65,
-        "y": -1
-      }
-    },
-    {
-      "type": "pcb_component",
-      "source_component_id": "simple_bug_3",
-      "pcb_component_id": "pcb_component_simple_bug_3",
-      "layer": "top",
-      "center": {
-        "x": -10.015882522757462,
-        "y": -0.29254949341672365
-      },
-      "rotation": 1.5707963267948966,
-      "width": 1.2000000000000006,
-      "height": 11.35999967488001
-    },
-    {
-      "type": "pcb_plated_hole",
-      "x": -10.015882522757462,
-      "y": -5.372549330856729,
-      "layers": [
-        "top",
-        "bottom"
-      ],
-      "hole_diameter": 1,
-      "shape": "circle",
-      "outer_diameter": 1.2,
-      "port_hints": [
-        "1"
-      ],
-      "pcb_component_id": "pcb_component_simple_bug_3",
-      "pcb_port_id": "pcb_port_36"
-    },
-    {
-      "type": "pcb_plated_hole",
-      "x": -10.015882522757462,
-      "y": -2.8325494121367263,
-      "layers": [
-        "top",
-        "bottom"
-      ],
-      "hole_diameter": 1,
-      "shape": "circle",
-      "outer_diameter": 1.2,
-      "port_hints": [
-        "2"
-      ],
-      "pcb_component_id": "pcb_component_simple_bug_3",
-      "pcb_port_id": "pcb_port_37"
-    },
-    {
-      "type": "pcb_plated_hole",
-      "x": -10.015882522757462,
-      "y": -0.29254949341672365,
-      "layers": [
-        "top",
-        "bottom"
-      ],
-      "hole_diameter": 1,
-      "shape": "circle",
-      "outer_diameter": 1.2,
-      "port_hints": [
-        "3"
-      ],
-      "pcb_component_id": "pcb_component_simple_bug_3",
-      "pcb_port_id": "pcb_port_38"
-    },
-    {
-      "type": "pcb_plated_hole",
-      "x": -10.015882522757462,
-      "y": 2.2474504253032785,
-      "layers": [
-        "top",
-        "bottom"
-      ],
-      "hole_diameter": 1,
-      "shape": "circle",
-      "outer_diameter": 1.2,
-      "port_hints": [
-        "4"
-      ],
-      "pcb_component_id": "pcb_component_simple_bug_3",
-      "pcb_port_id": "pcb_port_39"
-    },
-    {
-      "type": "pcb_plated_hole",
-      "x": -10.015882522757462,
-      "y": 4.787450344023282,
-      "layers": [
-        "top",
-        "bottom"
-      ],
-      "hole_diameter": 1,
-      "shape": "circle",
-      "outer_diameter": 1.2,
-      "port_hints": [
-        "5"
-      ],
-      "pcb_component_id": "pcb_component_simple_bug_3",
-      "pcb_port_id": "pcb_port_40"
-    },
-    {
-      "type": "source_component",
-      "source_component_id": "simple_resistor_0",
-      "name": "R1",
-      "supplier_part_numbers": {},
-      "ftype": "simple_resistor",
-      "resistance": "10k",
-      "schX": -5,
-      "schY": 0,
-      "schRotation": "90deg",
-      "sch_rotation": "90deg"
-    },
-    {
-      "type": "schematic_component",
-      "source_component_id": "simple_resistor_0",
-      "schematic_component_id": "schematic_component_simple_resistor_0",
-      "rotation": 1.5707963267948966,
-      "size": {
-        "width": 1,
-        "height": 0.3
-      },
-      "center": {
-        "x": -5,
-        "y": 0
-      }
-    },
-    {
-      "type": "source_port",
-      "name": "left",
-      "source_port_id": "source_port_41",
-      "source_component_id": "simple_resistor_0"
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_41",
-      "source_port_id": "source_port_41",
-      "center": {
-        "x": -5,
-        "y": -0.5
-      },
-      "facing_direction": "down",
-      "schematic_component_id": "schematic_component_simple_resistor_0"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_41",
-      "source_port_id": "source_port_41",
-      "pcb_component_id": "pcb_component_simple_resistor_0",
-      "x": 1.4299614017752447,
-      "y": 7.7243658318277015,
-      "layers": [
-        "top"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "right",
-      "source_port_id": "source_port_42",
-      "source_component_id": "simple_resistor_0"
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_42",
-      "source_port_id": "source_port_42",
-      "center": {
-        "x": -5,
-        "y": 0.5
-      },
-      "facing_direction": "up",
-      "schematic_component_id": "schematic_component_simple_resistor_0"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_42",
-      "source_port_id": "source_port_42",
-      "pcb_component_id": "pcb_component_simple_resistor_0",
-      "x": 2.4299614017752447,
-      "y": 7.7243658318277015,
-      "layers": [
-        "top"
-      ]
-    },
-    {
-      "type": "schematic_text",
-      "text": "R1",
-      "schematic_text_id": "schematic_text_82",
-      "schematic_component_id": "schematic_component_simple_resistor_0",
-      "anchor": "left",
-      "position": {
-        "x": -4.7,
-        "y": -0.20000000000000004
-      },
-      "rotation": 0
-    },
-    {
-      "type": "schematic_text",
-      "text": "10k",
-      "schematic_text_id": "schematic_text_83",
-      "schematic_component_id": "schematic_component_simple_resistor_0",
-      "anchor": "left",
-      "position": {
-        "x": -4.7,
-        "y": -1.8369701987210297e-17
-      },
-      "rotation": 0
-    },
-    {
-      "type": "pcb_component",
-      "source_component_id": "simple_resistor_0",
-      "pcb_component_id": "pcb_component_simple_resistor_0",
-      "layer": "top",
-      "center": {
-        "x": 1.9299614017752447,
-        "y": 7.7243658318277015
-      },
-      "rotation": 0,
-      "width": 1.6,
-      "height": 0.6000000000000001
-    },
-    {
-      "type": "pcb_smtpad",
-      "pcb_smtpad_id": "pcb_smtpad_3",
-      "shape": "rect",
-      "x": 1.4299614017752447,
-      "y": 7.7243658318277015,
-      "width": 0.6000000000000001,
-      "height": 0.6000000000000001,
-      "layer": "top",
-      "pcb_component_id": "pcb_component_simple_resistor_0",
-      "port_hints": [
-        "1",
-        "left"
-      ],
-      "pcb_port_id": "pcb_port_41"
-    },
-    {
-      "type": "pcb_smtpad",
-      "pcb_smtpad_id": "pcb_smtpad_10",
-      "shape": "rect",
-      "x": 2.4299614017752447,
-      "y": 7.7243658318277015,
-      "width": 0.6000000000000001,
-      "height": 0.6000000000000001,
-      "layer": "top",
-      "pcb_component_id": "pcb_component_simple_resistor_0",
-      "port_hints": [
-        "2",
-        "right"
-      ],
-      "pcb_port_id": "pcb_port_42"
-    },
-    {
-      "type": "source_component",
-      "source_component_id": "simple_capacitor_0",
-      "name": "C2",
-      "supplier_part_numbers": {},
-      "ftype": "simple_capacitor",
-      "capacitance": "1uF",
-      "schX": -4,
-      "schY": 1,
-      "schRotation": "-90deg",
-      "sch_rotation": "-90deg"
-    },
-    {
-      "type": "schematic_component",
-      "source_component_id": "simple_capacitor_0",
-      "schematic_component_id": "schematic_component_simple_capacitor_0",
-      "rotation": -1.5707963267948966,
-      "size": {
-        "width": 0.75,
-        "height": 0.75
-      },
-      "center": {
-        "x": -4,
-        "y": 1
-      }
-    },
-    {
-      "type": "source_port",
-      "name": "left",
-      "source_port_id": "source_port_43",
-      "source_component_id": "simple_capacitor_0"
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_43",
-      "source_port_id": "source_port_43",
-      "center": {
-        "x": -4,
-        "y": 1.5
-      },
-      "facing_direction": "up",
-      "schematic_component_id": "schematic_component_simple_capacitor_0"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_43",
-      "source_port_id": "source_port_43",
-      "pcb_component_id": "pcb_component_simple_capacitor_0",
-      "x": 1.2452744859109592,
-      "y": -3.519538247005859,
-      "layers": [
-        "top"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "right",
-      "source_port_id": "source_port_44",
-      "source_component_id": "simple_capacitor_0"
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_44",
-      "source_port_id": "source_port_44",
-      "center": {
-        "x": -4,
-        "y": 0.5
-      },
-      "facing_direction": "down",
-      "schematic_component_id": "schematic_component_simple_capacitor_0"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_44",
-      "source_port_id": "source_port_44",
-      "pcb_component_id": "pcb_component_simple_capacitor_0",
-      "x": 2.9452744859109594,
-      "y": -3.519538247005859,
-      "layers": [
-        "top"
-      ]
-    },
-    {
-      "type": "schematic_text",
-      "text": "C2",
-      "schematic_text_id": "schematic_text_84",
-      "schematic_component_id": "schematic_component_simple_capacitor_0",
-      "anchor": "left",
-      "position": {
-        "x": -4.3,
-        "y": 1.5
-      },
-      "rotation": 0
-    },
-    {
-      "type": "schematic_text",
-      "text": "1uF",
-      "schematic_text_id": "schematic_text_85",
-      "schematic_component_id": "schematic_component_simple_capacitor_0",
-      "anchor": "left",
-      "position": {
-        "x": -4.3,
-        "y": 1.3
-      },
-      "rotation": 0
-    },
-    {
-      "type": "pcb_component",
-      "source_component_id": "simple_capacitor_0",
-      "pcb_component_id": "pcb_component_simple_capacitor_0",
-      "layer": "top",
-      "center": {
-        "x": 2.0952744859109593,
-        "y": -3.519538247005859
-      },
-      "rotation": 0,
-      "width": 2.7,
-      "height": 1
-    },
-    {
-      "type": "pcb_smtpad",
-      "pcb_smtpad_id": "pcb_smtpad_4",
-      "shape": "rect",
-      "x": 1.2452744859109592,
-      "y": -3.519538247005859,
-      "width": 1,
-      "height": 1,
-      "layer": "top",
-      "pcb_component_id": "pcb_component_simple_capacitor_0",
-      "port_hints": [
-        "1",
-        "left"
-      ],
-      "pcb_port_id": "pcb_port_43"
-    },
-    {
-      "type": "pcb_smtpad",
-      "pcb_smtpad_id": "pcb_smtpad_11",
-      "shape": "rect",
-      "x": 2.9452744859109594,
-      "y": -3.519538247005859,
-      "width": 1,
-      "height": 1,
-      "layer": "top",
-      "pcb_component_id": "pcb_component_simple_capacitor_0",
-      "port_hints": [
-        "2",
-        "right"
-      ],
-      "pcb_port_id": "pcb_port_44"
-    },
-    {
-      "type": "source_component",
-      "source_component_id": "simple_capacitor_1",
-      "name": "C3",
-      "supplier_part_numbers": {},
-      "ftype": "simple_capacitor",
-      "capacitance": "1uF",
-      "schX": -6,
-      "schY": -2,
-      "schRotation": "-90deg",
-      "sch_rotation": "-90deg"
-    },
-    {
-      "type": "schematic_component",
-      "source_component_id": "simple_capacitor_1",
-      "schematic_component_id": "schematic_component_simple_capacitor_1",
-      "rotation": -1.5707963267948966,
-      "size": {
-        "width": 0.75,
-        "height": 0.75
-      },
-      "center": {
-        "x": -6,
-        "y": -2
-      }
-    },
-    {
-      "type": "source_port",
-      "name": "left",
-      "source_port_id": "source_port_45",
-      "source_component_id": "simple_capacitor_1"
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_45",
-      "source_port_id": "source_port_45",
-      "center": {
-        "x": -6,
-        "y": -1.5
-      },
-      "facing_direction": "up",
-      "schematic_component_id": "schematic_component_simple_capacitor_1"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_45",
-      "source_port_id": "source_port_45",
-      "pcb_component_id": "pcb_component_simple_capacitor_1",
-      "x": 8.851708433778615,
-      "y": -8.173734229851792,
-      "layers": [
-        "top"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "right",
-      "source_port_id": "source_port_46",
-      "source_component_id": "simple_capacitor_1"
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_46",
-      "source_port_id": "source_port_46",
-      "center": {
-        "x": -6,
-        "y": -2.5
-      },
-      "facing_direction": "down",
-      "schematic_component_id": "schematic_component_simple_capacitor_1"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_46",
-      "source_port_id": "source_port_46",
-      "pcb_component_id": "pcb_component_simple_capacitor_1",
-      "x": 10.551708433778614,
-      "y": -8.173734229851792,
-      "layers": [
-        "top"
-      ]
-    },
-    {
-      "type": "schematic_text",
-      "text": "C3",
-      "schematic_text_id": "schematic_text_86",
-      "schematic_component_id": "schematic_component_simple_capacitor_1",
-      "anchor": "left",
-      "position": {
-        "x": -6.3,
-        "y": -1.5
-      },
-      "rotation": 0
-    },
-    {
-      "type": "schematic_text",
-      "text": "1uF",
-      "schematic_text_id": "schematic_text_87",
-      "schematic_component_id": "schematic_component_simple_capacitor_1",
-      "anchor": "left",
-      "position": {
-        "x": -6.3,
-        "y": -1.7
-      },
-      "rotation": 0
-    },
-    {
-      "type": "pcb_component",
-      "source_component_id": "simple_capacitor_1",
-      "pcb_component_id": "pcb_component_simple_capacitor_1",
-      "layer": "top",
-      "center": {
-        "x": 9.701708433778615,
-        "y": -8.173734229851792
-      },
-      "rotation": 0,
-      "width": 2.7,
-      "height": 1
-    },
-    {
-      "type": "pcb_smtpad",
-      "pcb_smtpad_id": "pcb_smtpad_5",
-      "shape": "rect",
-      "x": 8.851708433778615,
-      "y": -8.173734229851792,
-      "width": 1,
-      "height": 1,
-      "layer": "top",
-      "pcb_component_id": "pcb_component_simple_capacitor_1",
-      "port_hints": [
-        "1",
-        "left"
-      ],
-      "pcb_port_id": "pcb_port_45"
-    },
-    {
-      "type": "pcb_smtpad",
-      "pcb_smtpad_id": "pcb_smtpad_12",
-      "shape": "rect",
-      "x": 10.551708433778614,
-      "y": -8.173734229851792,
-      "width": 1,
-      "height": 1,
-      "layer": "top",
-      "pcb_component_id": "pcb_component_simple_capacitor_1",
-      "port_hints": [
-        "2",
-        "right"
-      ],
-      "pcb_port_id": "pcb_port_46"
-    },
-    {
-      "type": "source_component",
-      "source_component_id": "simple_bug_4",
-      "name": "Q1",
-      "supplier_part_numbers": {},
-      "ftype": "simple_bug",
-      "schX": -8,
-      "schY": -2,
-      "pcbX": 10,
-      "pcbY": 10,
-      "pinLabels": {
-        "1": "G",
-        "2": "S",
-        "3": "D"
-      },
-      "schPortArrangement": {
-        "leftSide": {
-          "direction": "top-to-bottom",
-          "pins": [
-            3
-          ]
-        },
-        "bottomSide": {
-          "direction": "left-to-right",
-          "pins": [
-            1
-          ]
-        },
-        "rightSide": {
-          "direction": "left-to-right",
-          "pins": [
-            2
-          ]
-        },
-        "left_side": {
-          "direction": "top-to-bottom",
-          "pins": [
-            3
-          ]
-        },
-        "bottom_side": {
-          "direction": "left-to-right",
-          "pins": [
-            1
-          ]
-        },
-        "right_side": {
-          "direction": "left-to-right",
-          "pins": [
-            2
-          ]
-        }
-      },
-      "cad_model": {
-        "rotationOffset": {
-          "x": 0,
-          "y": 0,
-          "z": 180
-        },
-        "objUrl": "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=d777607a152f4f3aac9bb0d0c14ed6fd&pn=C4355039",
-        "rotation_offset": {
-          "x": 0,
-          "y": 0,
-          "z": 180
-        },
-        "obj_url": "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=d777607a152f4f3aac9bb0d0c14ed6fd&pn=C4355039"
-      },
-      "pin_labels": {
-        "1": "G",
-        "2": "S",
-        "3": "D"
-      },
-      "sch_port_arrangement": {
-        "leftSide": {
-          "direction": "top-to-bottom",
-          "pins": [
-            3
-          ]
-        },
-        "bottomSide": {
-          "direction": "left-to-right",
-          "pins": [
-            1
-          ]
-        },
-        "rightSide": {
-          "direction": "left-to-right",
-          "pins": [
-            2
-          ]
-        },
-        "left_side": {
-          "direction": "top-to-bottom",
-          "pins": [
-            3
-          ]
-        },
-        "bottom_side": {
-          "direction": "left-to-right",
-          "pins": [
-            1
-          ]
-        },
-        "right_side": {
-          "direction": "left-to-right",
-          "pins": [
-            2
-          ]
-        }
-      }
-    },
-    {
-      "type": "schematic_component",
-      "source_component_id": "simple_bug_4",
-      "schematic_component_id": "schematic_component_simple_bug_4",
-      "rotation": 0,
-      "size": {
-        "width": 1,
-        "height": 1
-      },
-      "center": {
-        "x": -8,
-        "y": -2
-      },
-      "port_labels": {
-        "1": "G",
-        "2": "S",
-        "3": "D"
-      },
-      "port_arrangement": {
-        "left_side": {
-          "direction": "top-to-bottom",
-          "pins": [
-            3
-          ]
-        },
-        "right_side": {
-          "direction": "left-to-right",
-          "pins": [
-            2
-          ]
-        },
-        "bottom_side": {
-          "direction": "left-to-right",
-          "pins": [
-            1
-          ]
-        }
-      }
-    },
-    {
-      "type": "source_port",
-      "name": "D",
-      "source_port_id": "source_port_47",
-      "source_component_id": "simple_bug_4",
-      "pin_number": 3,
-      "port_hints": [
-        "D",
-        "3"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_47",
-      "source_port_id": "source_port_47",
-      "center": {
-        "x": -8.75,
-        "y": -2
-      },
-      "facing_direction": "left",
-      "schematic_component_id": "schematic_component_simple_bug_4"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_47",
-      "schematic_text_id": "schematic_text_91",
-      "text": "3",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": -8.626256313292354,
-        "y": -2.123743686707646
-      },
-      "schematic_component_id": "schematic_component_simple_bug_4"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_47",
-      "source_port_id": "source_port_47",
-      "pcb_component_id": "pcb_component_simple_bug_4",
-      "x": 9,
-      "y": 10,
-      "layers": [
-        "top"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "G",
-      "source_port_id": "source_port_48",
-      "source_component_id": "simple_bug_4",
-      "pin_number": 1,
-      "port_hints": [
-        "G",
-        "1"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_48",
-      "source_port_id": "source_port_48",
-      "center": {
-        "x": -8,
-        "y": -2.75
-      },
-      "facing_direction": "down",
-      "schematic_component_id": "schematic_component_simple_bug_4"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_48",
-      "schematic_text_id": "schematic_text_92",
-      "text": "1",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": -7.876256313292354,
-        "y": -2.6262563132923544
-      },
-      "schematic_component_id": "schematic_component_simple_bug_4"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_48",
-      "source_port_id": "source_port_48",
-      "pcb_component_id": "pcb_component_simple_bug_4",
-      "x": 11,
-      "y": 10.95,
-      "layers": [
-        "top"
-      ]
-    },
-    {
-      "type": "source_port",
-      "name": "S",
-      "source_port_id": "source_port_49",
-      "source_component_id": "simple_bug_4",
-      "pin_number": 2,
-      "port_hints": [
-        "S",
-        "2"
-      ]
-    },
-    {
-      "type": "schematic_port",
-      "schematic_port_id": "schematic_port_49",
-      "source_port_id": "source_port_49",
-      "center": {
-        "x": -7.25,
-        "y": -2
-      },
-      "facing_direction": "right",
-      "schematic_component_id": "schematic_component_simple_bug_4"
-    },
-    {
-      "type": "schematic_text",
-      "schematic_port_id": "schematic_port_49",
-      "schematic_text_id": "schematic_text_93",
-      "text": "2",
-      "anchor": "center",
-      "rotation": 0,
-      "position": {
-        "x": -7.373743686707646,
-        "y": -2.123743686707646
-      },
-      "schematic_component_id": "schematic_component_simple_bug_4"
-    },
-    {
-      "type": "pcb_port",
-      "pcb_port_id": "pcb_port_49",
-      "source_port_id": "source_port_49",
-      "pcb_component_id": "pcb_component_simple_bug_4",
-      "x": 11,
-      "y": 9.05,
-      "layers": [
-        "top"
-      ]
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_88",
-      "schematic_component_id": "schematic_component_simple_bug_4",
-      "text": "D",
-      "anchor": "left",
-      "rotation": 0,
-      "position": {
-        "x": -8.35,
-        "y": -2
-      }
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_89",
-      "schematic_component_id": "schematic_component_simple_bug_4",
-      "text": "G",
-      "anchor": "right",
-      "rotation": 1.5707963267948966,
-      "position": {
-        "x": -8,
-        "y": -3.15
-      }
-    },
-    {
-      "type": "schematic_text",
-      "schematic_text_id": "schematic_text_90",
-      "schematic_component_id": "schematic_component_simple_bug_4",
-      "text": "S",
-      "anchor": "right",
-      "rotation": 0,
-      "position": {
-        "x": -7.65,
-        "y": -2
-      }
-    },
-    {
-      "type": "pcb_component",
-      "source_component_id": "simple_bug_4",
-      "pcb_component_id": "pcb_component_simple_bug_4",
-      "layer": "top",
-      "center": {
-        "x": 10,
-        "y": 10
-      },
-      "rotation": 0,
-      "width": 3.2500101599996754,
-      "height": 2.5999985776000436
-    },
-    {
-      "type": "pcb_smtpad",
-      "pcb_smtpad_id": "pcb_smtpad_6",
-      "shape": "rect",
-      "x": 11,
-      "y": 10.95,
-      "width": 1.2500101599996745,
-      "height": 0.6999985776000455,
-      "layer": "top",
-      "pcb_component_id": "pcb_component_simple_bug_4",
-      "port_hints": [
-        "1"
-      ],
-      "pcb_port_id": "pcb_port_48"
-    },
-    {
-      "type": "pcb_smtpad",
-      "pcb_smtpad_id": "pcb_smtpad_13",
-      "shape": "rect",
-      "x": 11,
-      "y": 9.05,
-      "width": 1.2500101599996745,
-      "height": 0.6999985776000455,
-      "layer": "top",
-      "pcb_component_id": "pcb_component_simple_bug_4",
-      "port_hints": [
-        "2"
-      ],
-      "pcb_port_id": "pcb_port_49"
-    },
-    {
-      "type": "pcb_smtpad",
-      "pcb_smtpad_id": "pcb_smtpad_16",
-      "shape": "rect",
-      "x": 9,
-      "y": 10,
-      "width": 1.2500101599996745,
-      "height": 0.6999985776000455,
-      "layer": "top",
-      "pcb_component_id": "pcb_component_simple_bug_4",
-      "port_hints": [
-        "3"
-      ],
-      "pcb_port_id": "pcb_port_47"
-    },
-    {
-      "type": "cad_component",
-      "cad_component_id": "cad_component_0",
-      "source_component_id": "simple_bug_4",
-      "pcb_component_id": "pcb_component_simple_bug_4",
-      "position": {
-        "x": 10,
-        "y": 10,
-        "z": 0.6
-      },
-      "rotation": {
-        "x": 0,
-        "y": 0,
-        "z": 180
-      },
-      "layer": "top",
-      "model_obj_url": "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=d777607a152f4f3aac9bb0d0c14ed6fd&pn=C4355039"
-    },
-    {
-      "pcb_error_id": "pcb_error_0",
-      "type": "pcb_error",
-      "message": "No elements found for selector: \".U2\"",
-      "error_type": "pcb_placement_error"
-    },
-    {
-      "type": "pcb_trace_hint",
-      "pcb_trace_hint_id": "pcb_trace_hint_0",
-      "pcb_component_id": "pcb_component_simple_capacitor_0",
-      "pcb_port_id": "pcb_port_43",
-      "route": [
-        {
-          "x": -0.46567037894333296,
-          "y": -3.0697423658834904,
-          "via": false
-        }
-      ]
-    },
-    {
-      "type": "pcb_trace_hint",
-      "pcb_trace_hint_id": "pcb_trace_hint_1",
-      "pcb_component_id": "pcb_component_simple_bug_0",
-      "pcb_port_id": "pcb_port_0",
-      "route": [
-        {
-          "x": -0.87561338712114,
-          "y": -2.3188874876950147,
-          "via": false
-        }
-      ]
-    },
-    {
-      "type": "source_net",
-      "member_source_group_ids": [],
-      "source_net_id": "net_0",
-      "name": "GND"
-    },
-    {
-      "type": "source_net",
-      "member_source_group_ids": [],
-      "source_net_id": "net_1",
-      "name": "VMOTOR"
-    },
-    {
-      "type": "source_net",
-      "member_source_group_ids": [],
-      "source_net_id": "net_2",
-      "name": "PWMB"
-    },
-    {
-      "type": "source_net",
-      "member_source_group_ids": [],
-      "source_net_id": "net_3",
-      "name": "BIN2"
-    },
-    {
-      "type": "source_net",
-      "member_source_group_ids": [],
-      "source_net_id": "net_4",
-      "name": "BIN1"
-    },
-    {
-      "type": "source_net",
-      "member_source_group_ids": [],
-      "source_net_id": "net_5",
-      "name": "AIN1"
-    },
-    {
-      "type": "source_net",
-      "member_source_group_ids": [],
-      "source_net_id": "net_6",
-      "name": "AIN2"
-    },
-    {
-      "type": "source_net",
-      "member_source_group_ids": [],
-      "source_net_id": "net_7",
-      "name": "PWMA"
-    },
-    {
-      "type": "source_net",
-      "member_source_group_ids": [],
-      "source_net_id": "net_8",
-      "name": "PWRIN"
-    },
-    {
-      "type": "source_net",
-      "member_source_group_ids": [],
-      "source_net_id": "net_9",
-      "name": "VCC"
-    },
-    {
-      "type": "source_net",
-      "member_source_group_ids": [],
-      "source_net_id": "net_10",
-      "name": "STBY"
-    },
-    {
-      "type": "source_trace",
-      "source_trace_id": "source_trace_0",
-      "connected_source_port_ids": [
-        "source_port_22",
-        "source_port_36"
-      ]
-    },
-    {
-      "type": "schematic_trace",
-      "source_trace_id": "source_trace_0",
-      "schematic_trace_id": "schematic_trace_0",
-      "edges": [
-        {
-          "from": {
-            "x": 4.1000000000000005,
-            "y": 1
-          },
-          "to": {
-            "x": 4.1000000000000005,
-            "y": 4.5
-          }
-        },
-        {
-          "from": {
-            "x": 4.1000000000000005,
-            "y": 4.5
-          },
-          "to": {
-            "x": 1.3,
-            "y": 4.5
-          }
-        },
-        {
-          "from": {
-            "x": 1.125,
-            "y": 4.5,
-            "ti": 0
-          },
-          "to": {
-            "x": 1.3,
-            "y": 4.5
-          }
-        },
-        {
-          "from": {
-            "x": 4.25,
-            "y": 1,
-            "ti": 1
-          },
-          "to": {
-            "x": 4.1000000000000005,
-            "y": 1
-          }
-        }
-      ]
-    },
-    {
-      "type": "pcb_trace",
-      "pcb_trace_id": "pcb_trace_0",
-      "source_trace_id": "source_trace_0",
-      "route": [
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": -1.799999999999999,
-          "y": -1.1999999999999993
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": -2.3999999999999986,
-          "y": -1.7999999999999998
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": -2.5999999999999996,
-          "y": -1.7999999999999998
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": -3,
-          "y": -2.2
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": -3.1999999999999993,
-          "y": -2.2
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": -3.799999999999999,
-          "y": -2.8
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": -4.799999999999999,
-          "y": -2.8
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": -5.199999999999999,
-          "y": -3.2
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": -7.3999999999999995,
-          "y": -3.2
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": -9.399999999999999,
-          "y": -5.2
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": -9.8,
-          "y": -5.2
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": -10,
-          "y": -5.4
-        }
-      ]
-    },
-    {
-      "type": "source_trace",
-      "source_trace_id": "source_trace_1",
-      "connected_source_port_ids": [
-        "source_port_21",
-        "source_port_22"
-      ]
-    },
-    {
-      "type": "schematic_trace",
-      "source_trace_id": "source_trace_1",
-      "schematic_trace_id": "schematic_trace_1",
-      "edges": [
-        {
-          "from": {
-            "x": 1.3,
-            "y": 3.7
-          },
-          "to": {
-            "x": 1.3,
-            "y": 4.5
-          }
-        },
-        {
-          "from": {
-            "x": 1.125,
-            "y": 3.75,
-            "ti": 0
-          },
-          "to": {
-            "x": 1.3,
-            "y": 3.7
-          }
-        },
-        {
-          "from": {
-            "x": 1.125,
-            "y": 4.5,
-            "ti": 1
-          },
-          "to": {
-            "x": 1.3,
-            "y": 4.5
-          }
-        }
-      ]
-    },
-    {
-      "type": "pcb_trace",
-      "pcb_trace_id": "pcb_trace_1",
-      "source_trace_id": "source_trace_1",
-      "route": [
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": -1.8000000000000007,
-          "y": -0.39999999999999947
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": -1.8000000000000007,
-          "y": -1.2000000000000002
-        }
-      ]
-    },
-    {
-      "type": "source_trace",
-      "connected_source_port_ids": [
-        "source_port_18"
-      ],
-      "connected_source_net_ids": [
-        "net_0"
-      ],
-      "source_trace_id": "source_trace_2"
-    },
-    {
-      "type": "schematic_net_label",
-      "source_net_id": "net_0",
-      "text": "GND",
-      "anchor_side": "left",
-      "center": {
-        "x": 1.625,
-        "y": 1.5
-      }
-    },
-    {
-      "type": "schematic_trace",
-      "schematic_trace_id": "schematic_trace_2",
-      "source_trace_id": "source_trace_2",
-      "edges": [
-        {
-          "from": {
-            "x": 1.125,
-            "y": 1.5
-          },
-          "to": {
-            "x": 1.425,
-            "y": 1.5
-          },
-          "from_schematic_port_id": "schematic_port_18"
-        }
-      ]
-    },
-    {
-      "type": "source_trace",
-      "connected_source_port_ids": [
-        "source_port_17"
-      ],
-      "connected_source_net_ids": [
-        "net_0"
-      ],
-      "source_trace_id": "source_trace_3"
-    },
-    {
-      "type": "schematic_net_label",
-      "source_net_id": "net_0",
-      "text": "GND",
-      "anchor_side": "left",
-      "center": {
-        "x": 1.625,
-        "y": 0.75
-      }
-    },
-    {
-      "type": "schematic_trace",
-      "schematic_trace_id": "schematic_trace_3",
-      "source_trace_id": "source_trace_3",
-      "edges": [
-        {
-          "from": {
-            "x": 1.125,
-            "y": 0.75
-          },
-          "to": {
-            "x": 1.425,
-            "y": 0.75
-          },
-          "from_schematic_port_id": "schematic_port_17"
-        }
-      ]
-    },
-    {
-      "type": "source_trace",
-      "source_trace_id": "source_trace_4",
-      "connected_source_port_ids": [
-        "source_port_20",
-        "source_port_37"
-      ]
-    },
-    {
-      "type": "schematic_trace",
-      "source_trace_id": "source_trace_4",
-      "schematic_trace_id": "schematic_trace_4",
-      "edges": [
-        {
-          "from": {
-            "x": 1.3,
-            "y": 3
-          },
-          "to": {
-            "x": 1.3,
-            "y": 2.5
-          }
-        },
-        {
-          "from": {
-            "x": 1.3,
-            "y": 2.5
-          },
-          "to": {
-            "x": 3.7,
-            "y": 2.5
-          }
-        },
-        {
-          "from": {
-            "x": 3.7,
-            "y": 2.5
-          },
-          "to": {
-            "x": 3.7,
-            "y": 0.5
-          }
-        },
-        {
-          "from": {
-            "x": 3.7,
-            "y": 0.5
-          },
-          "to": {
-            "x": 4.1000000000000005,
-            "y": 0.5
-          }
-        },
-        {
-          "from": {
-            "x": 1.125,
-            "y": 3,
-            "ti": 0
-          },
-          "to": {
-            "x": 1.3,
-            "y": 3
-          }
-        },
-        {
-          "from": {
-            "x": 4.25,
-            "y": 0.5,
-            "ti": 1
-          },
-          "to": {
-            "x": 4.1000000000000005,
-            "y": 0.5
-          }
-        }
-      ]
-    },
-    {
-      "type": "pcb_trace",
-      "pcb_trace_id": "pcb_trace_2",
-      "source_trace_id": "source_trace_4",
-      "route": [
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": -1.799999999999999,
-          "y": 1.4000000000000004
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": -5.199999999999999,
-          "y": 1.4000000000000004
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": -5.799999999999999,
-          "y": 0.7999999999999998
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": -6,
-          "y": 0.7999999999999998
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": -7,
-          "y": -0.20000000000000018
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": -7.3999999999999995,
-          "y": -0.20000000000000018
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": -10,
-          "y": -2.8000000000000007
-        }
-      ]
-    },
-    {
-      "type": "source_trace",
-      "source_trace_id": "source_trace_5",
-      "connected_source_port_ids": [
-        "source_port_19",
-        "source_port_20"
-      ]
-    },
-    {
-      "type": "schematic_trace",
-      "source_trace_id": "source_trace_5",
-      "schematic_trace_id": "schematic_trace_5",
-      "edges": [
-        {
-          "from": {
-            "x": 1.3,
-            "y": 2.2
-          },
-          "to": {
-            "x": 1.3,
-            "y": 3
-          }
-        },
-        {
-          "from": {
-            "x": 1.125,
-            "y": 2.25,
-            "ti": 0
-          },
-          "to": {
-            "x": 1.3,
-            "y": 2.2
-          }
-        },
-        {
-          "from": {
-            "x": 1.125,
-            "y": 3,
-            "ti": 1
-          },
-          "to": {
-            "x": 1.3,
-            "y": 3
-          }
-        }
-      ]
-    },
-    {
-      "type": "pcb_trace",
-      "pcb_trace_id": "pcb_trace_3",
-      "source_trace_id": "source_trace_5",
-      "route": []
-    },
-    {
-      "type": "source_trace",
-      "source_trace_id": "source_trace_6",
-      "connected_source_port_ids": [
-        "source_port_12",
-        "source_port_39"
-      ]
-    },
-    {
-      "type": "schematic_trace",
-      "source_trace_id": "source_trace_6",
-      "schematic_trace_id": "schematic_trace_6",
-      "edges": [
-        {
-          "from": {
-            "x": 1.3,
-            "y": -3
-          },
-          "to": {
-            "x": 2.1,
-            "y": -3
-          }
-        },
-        {
-          "from": {
-            "x": 2.1,
-            "y": -3
-          },
-          "to": {
-            "x": 2.1,
-            "y": -0.5
-          }
-        },
-        {
-          "from": {
-            "x": 2.1,
-            "y": -0.5
-          },
-          "to": {
-            "x": 4.1000000000000005,
-            "y": -0.5
-          }
-        },
-        {
-          "from": {
-            "x": 1.125,
-            "y": -3,
-            "ti": 0
-          },
-          "to": {
-            "x": 1.3,
-            "y": -3
-          }
-        },
-        {
-          "from": {
-            "x": 4.25,
-            "y": -0.5,
-            "ti": 1
-          },
-          "to": {
-            "x": 4.1000000000000005,
-            "y": -0.5
-          }
-        }
-      ]
-    },
-    {
-      "type": "pcb_trace",
-      "pcb_trace_id": "pcb_trace_4",
-      "source_trace_id": "source_trace_6",
-      "route": []
-    },
-    {
-      "type": "source_trace",
-      "source_trace_id": "source_trace_7",
-      "connected_source_port_ids": [
-        "source_port_11",
-        "source_port_12"
-      ]
-    },
-    {
-      "type": "schematic_trace",
-      "source_trace_id": "source_trace_7",
-      "schematic_trace_id": "schematic_trace_7",
-      "edges": [
-        {
-          "from": {
-            "x": 1.3,
-            "y": -3
-          },
-          "to": {
-            "x": 1.3,
-            "y": -3.7
-          }
-        },
-        {
-          "from": {
-            "x": 1.125,
-            "y": -3.75,
-            "ti": 0
-          },
-          "to": {
-            "x": 1.3,
-            "y": -3.7
-          }
-        },
-        {
-          "from": {
-            "x": 1.125,
-            "y": -3,
-            "ti": 1
-          },
-          "to": {
-            "x": 1.3,
-            "y": -3
-          }
-        }
-      ]
-    },
-    {
-      "type": "pcb_trace",
-      "pcb_trace_id": "pcb_trace_5",
-      "source_trace_id": "source_trace_7",
-      "route": [
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": -1.8000000000000007,
-          "y": 2.8
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": -1.8000000000000007,
-          "y": 3.4000000000000004
-        }
-      ]
-    },
-    {
-      "type": "source_trace",
-      "connected_source_port_ids": [
-        "source_port_10"
-      ],
-      "connected_source_net_ids": [
-        "net_0"
-      ],
-      "source_trace_id": "source_trace_8"
-    },
-    {
-      "type": "schematic_net_label",
-      "source_net_id": "net_0",
-      "text": "GND",
-      "anchor_side": "left",
-      "center": {
-        "x": 1.625,
-        "y": -4.5
-      }
-    },
-    {
-      "type": "schematic_trace",
-      "schematic_trace_id": "schematic_trace_8",
-      "source_trace_id": "source_trace_8",
-      "edges": [
-        {
-          "from": {
-            "x": 1.125,
-            "y": -4.5
-          },
-          "to": {
-            "x": 1.425,
-            "y": -4.5
-          },
-          "from_schematic_port_id": "schematic_port_10"
-        }
-      ]
-    },
-    {
-      "type": "source_trace",
-      "source_trace_id": "source_trace_9",
-      "connected_source_port_ids": [
-        "source_port_9",
-        "source_port_10"
-      ]
-    },
-    {
-      "type": "schematic_trace",
-      "source_trace_id": "source_trace_9",
-      "schematic_trace_id": "schematic_trace_9",
-      "edges": [
-        {
-          "from": {
-            "x": 1.2,
-            "y": -4.5
-          },
-          "to": {
-            "x": 1.2,
-            "y": -5.2
-          }
-        },
-        {
-          "from": {
-            "x": 1.2,
-            "y": -5.2
-          },
-          "to": {
-            "x": 1.3,
-            "y": -5.2
-          }
-        },
-        {
-          "from": {
-            "x": 1.125,
-            "y": -5.25,
-            "ti": 0
-          },
-          "to": {
-            "x": 1.3,
-            "y": -5.2
-          }
-        },
-        {
-          "from": {
-            "x": 1.125,
-            "y": -4.5,
-            "ti": 1
-          },
-          "to": {
-            "x": 1.2,
-            "y": -4.5
-          }
-        }
-      ]
-    },
-    {
-      "type": "pcb_trace",
-      "pcb_trace_id": "pcb_trace_6",
-      "source_trace_id": "source_trace_9",
-      "route": []
-    },
-    {
-      "type": "source_trace",
-      "source_trace_id": "source_trace_10",
-      "connected_source_port_ids": [
-        "source_port_14",
-        "source_port_40"
-      ]
-    },
-    {
-      "type": "schematic_trace",
-      "source_trace_id": "source_trace_10",
-      "schematic_trace_id": "schematic_trace_10",
-      "edges": [
-        {
-          "from": {
-            "x": 1.3,
-            "y": -1.5
-          },
-          "to": {
-            "x": 2,
-            "y": -1.5
-          }
-        },
-        {
-          "from": {
-            "x": 2,
-            "y": -1.5
-          },
-          "to": {
-            "x": 2,
-            "y": -1
-          }
-        },
-        {
-          "from": {
-            "x": 2,
-            "y": -1
-          },
-          "to": {
-            "x": 4.1000000000000005,
-            "y": -1
-          }
-        },
-        {
-          "from": {
-            "x": 1.125,
-            "y": -1.5,
-            "ti": 0
-          },
-          "to": {
-            "x": 1.3,
-            "y": -1.5
-          }
-        },
-        {
-          "from": {
-            "x": 4.25,
-            "y": -1,
-            "ti": 1
-          },
-          "to": {
-            "x": 4.1000000000000005,
-            "y": -1
-          }
-        }
-      ]
-    },
-    {
-      "type": "pcb_trace",
-      "pcb_trace_id": "pcb_trace_7",
-      "source_trace_id": "source_trace_10",
-      "route": []
-    },
-    {
-      "type": "source_trace",
-      "source_trace_id": "source_trace_11",
-      "connected_source_port_ids": [
-        "source_port_13",
-        "source_port_14"
-      ]
-    },
-    {
-      "type": "schematic_trace",
-      "source_trace_id": "source_trace_11",
-      "schematic_trace_id": "schematic_trace_11",
-      "edges": [
-        {
-          "from": {
-            "x": 1.3,
-            "y": -1.5
-          },
-          "to": {
-            "x": 1.3,
-            "y": -2.2
-          }
-        },
-        {
-          "from": {
-            "x": 1.125,
-            "y": -2.25,
-            "ti": 0
-          },
-          "to": {
-            "x": 1.3,
-            "y": -2.2
-          }
-        },
-        {
-          "from": {
-            "x": 1.125,
-            "y": -1.5,
-            "ti": 1
-          },
-          "to": {
-            "x": 1.3,
-            "y": -1.5
-          }
-        }
-      ]
-    },
-    {
-      "type": "pcb_trace",
-      "pcb_trace_id": "pcb_trace_8",
-      "source_trace_id": "source_trace_11",
-      "route": [
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": -1.8000000000000007,
-          "y": 5.4
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": -1.8000000000000007,
-          "y": 6.000000000000001
-        }
-      ]
-    },
-    {
-      "type": "source_trace",
-      "connected_source_port_ids": [
-        "source_port_16"
-      ],
-      "connected_source_net_ids": [
-        "net_1"
-      ],
-      "source_trace_id": "source_trace_12"
-    },
-    {
-      "type": "schematic_net_label",
-      "source_net_id": "net_1",
-      "text": "VMOTOR",
-      "anchor_side": "left",
-      "center": {
-        "x": 1.725,
-        "y": 0
-      }
-    },
-    {
-      "type": "schematic_trace",
-      "schematic_trace_id": "schematic_trace_12",
-      "source_trace_id": "source_trace_12",
-      "edges": [
-        {
-          "from": {
-            "x": 1.125,
-            "y": 0
-          },
-          "to": {
-            "x": 1.385,
-            "y": 0
-          },
-          "from_schematic_port_id": "schematic_port_16"
-        }
-      ]
-    },
-    {
-      "type": "source_trace",
-      "connected_source_port_ids": [
-        "source_port_15"
-      ],
-      "connected_source_net_ids": [
-        "net_1"
-      ],
-      "source_trace_id": "source_trace_13"
-    },
-    {
-      "type": "schematic_net_label",
-      "source_net_id": "net_1",
-      "text": "VMOTOR",
-      "anchor_side": "left",
-      "center": {
-        "x": 1.725,
-        "y": -0.75
-      }
-    },
-    {
-      "type": "schematic_trace",
-      "schematic_trace_id": "schematic_trace_13",
-      "source_trace_id": "source_trace_13",
-      "edges": [
-        {
-          "from": {
-            "x": 1.125,
-            "y": -0.75
-          },
-          "to": {
-            "x": 1.385,
-            "y": -0.75
-          },
-          "from_schematic_port_id": "schematic_port_15"
-        }
-      ]
-    },
-    {
-      "type": "source_trace",
-      "connected_source_port_ids": [
-        "source_port_7"
-      ],
-      "connected_source_net_ids": [
-        "net_2"
-      ],
-      "source_trace_id": "source_trace_14"
-    },
-    {
-      "type": "schematic_net_label",
-      "source_net_id": "net_2",
-      "text": "PWMB",
-      "anchor_side": "right",
-      "center": {
-        "x": -1.625,
-        "y": -2.25
-      }
-    },
-    {
-      "type": "schematic_trace",
-      "schematic_trace_id": "schematic_trace_14",
-      "source_trace_id": "source_trace_14",
-      "edges": [
-        {
-          "from": {
-            "x": -1.125,
-            "y": -2.25
-          },
-          "to": {
-            "x": -1.425,
-            "y": -2.25
-          },
-          "from_schematic_port_id": "schematic_port_7"
-        }
-      ]
-    },
-    {
-      "type": "source_trace",
-      "connected_source_port_ids": [
-        "source_port_6"
-      ],
-      "connected_source_net_ids": [
-        "net_3"
-      ],
-      "source_trace_id": "source_trace_15"
-    },
-    {
-      "type": "schematic_net_label",
-      "source_net_id": "net_3",
-      "text": "BIN2",
-      "anchor_side": "right",
-      "center": {
-        "x": -1.625,
-        "y": -1.5
-      }
-    },
-    {
-      "type": "schematic_trace",
-      "schematic_trace_id": "schematic_trace_15",
-      "source_trace_id": "source_trace_15",
-      "edges": [
-        {
-          "from": {
-            "x": -1.125,
-            "y": -1.5
-          },
-          "to": {
-            "x": -1.425,
-            "y": -1.5
-          },
-          "from_schematic_port_id": "schematic_port_6"
-        }
-      ]
-    },
-    {
-      "type": "source_trace",
-      "connected_source_port_ids": [
-        "source_port_5"
-      ],
-      "connected_source_net_ids": [
-        "net_4"
-      ],
-      "source_trace_id": "source_trace_16"
-    },
-    {
-      "type": "schematic_net_label",
-      "source_net_id": "net_4",
-      "text": "BIN1",
-      "anchor_side": "right",
-      "center": {
-        "x": -1.625,
-        "y": -0.75
-      }
-    },
-    {
-      "type": "schematic_trace",
-      "schematic_trace_id": "schematic_trace_16",
-      "source_trace_id": "source_trace_16",
-      "edges": [
-        {
-          "from": {
-            "x": -1.125,
-            "y": -0.75
-          },
-          "to": {
-            "x": -1.425,
-            "y": -0.75
-          },
-          "from_schematic_port_id": "schematic_port_5"
-        }
-      ]
-    },
-    {
-      "type": "source_trace",
-      "connected_source_port_ids": [
-        "source_port_8"
-      ],
-      "connected_source_net_ids": [
-        "net_0"
-      ],
-      "source_trace_id": "source_trace_17"
-    },
-    {
-      "type": "schematic_net_label",
-      "source_net_id": "net_0",
-      "text": "GND",
-      "anchor_side": "right",
-      "center": {
-        "x": -1.625,
-        "y": -3
-      }
-    },
-    {
-      "type": "schematic_trace",
-      "schematic_trace_id": "schematic_trace_17",
-      "source_trace_id": "source_trace_17",
-      "edges": [
-        {
-          "from": {
-            "x": -1.125,
-            "y": -3
-          },
-          "to": {
-            "x": -1.425,
-            "y": -3
-          },
-          "from_schematic_port_id": "schematic_port_8"
-        }
-      ]
-    },
-    {
-      "type": "source_trace",
-      "connected_source_port_ids": [
-        "source_port_1"
-      ],
-      "connected_source_net_ids": [
-        "net_5"
-      ],
-      "source_trace_id": "source_trace_18"
-    },
-    {
-      "type": "schematic_net_label",
-      "source_net_id": "net_5",
-      "text": "AIN1",
-      "anchor_side": "right",
-      "center": {
-        "x": -1.625,
-        "y": 2.25
-      }
-    },
-    {
-      "type": "schematic_trace",
-      "schematic_trace_id": "schematic_trace_18",
-      "source_trace_id": "source_trace_18",
-      "edges": [
-        {
-          "from": {
-            "x": -1.125,
-            "y": 2.25
-          },
-          "to": {
-            "x": -1.425,
-            "y": 2.25
-          },
-          "from_schematic_port_id": "schematic_port_1"
-        }
-      ]
-    },
-    {
-      "type": "source_trace",
-      "connected_source_port_ids": [
-        "source_port_2"
-      ],
-      "connected_source_net_ids": [
-        "net_6"
-      ],
-      "source_trace_id": "source_trace_19"
-    },
-    {
-      "type": "schematic_net_label",
-      "source_net_id": "net_6",
-      "text": "AIN2",
-      "anchor_side": "right",
-      "center": {
-        "x": -1.625,
-        "y": 1.5
-      }
-    },
-    {
-      "type": "schematic_trace",
-      "schematic_trace_id": "schematic_trace_19",
-      "source_trace_id": "source_trace_19",
-      "edges": [
-        {
-          "from": {
-            "x": -1.125,
-            "y": 1.5
-          },
-          "to": {
-            "x": -1.425,
-            "y": 1.5
-          },
-          "from_schematic_port_id": "schematic_port_2"
-        }
-      ]
-    },
-    {
-      "type": "source_trace",
-      "connected_source_port_ids": [
-        "source_port_3"
-      ],
-      "connected_source_net_ids": [
-        "net_7"
-      ],
-      "source_trace_id": "source_trace_20"
-    },
-    {
-      "type": "schematic_net_label",
-      "source_net_id": "net_7",
-      "text": "PWMA",
-      "anchor_side": "right",
-      "center": {
-        "x": -1.625,
-        "y": 0.75
-      }
-    },
-    {
-      "type": "schematic_trace",
-      "schematic_trace_id": "schematic_trace_20",
-      "source_trace_id": "source_trace_20",
-      "edges": [
-        {
-          "from": {
-            "x": -1.125,
-            "y": 0.75
-          },
-          "to": {
-            "x": -1.425,
-            "y": 0.75
-          },
-          "from_schematic_port_id": "schematic_port_3"
-        }
-      ]
-    },
-    {
-      "type": "source_trace",
-      "connected_source_port_ids": [
-        "source_port_23"
-      ],
-      "connected_source_net_ids": [
-        "net_1"
-      ],
-      "source_trace_id": "source_trace_21"
-    },
-    {
-      "type": "schematic_net_label",
-      "source_net_id": "net_1",
-      "text": "VMOTOR",
-      "anchor_side": "left",
-      "center": {
-        "x": 1.725,
-        "y": 5.25
-      }
-    },
-    {
-      "type": "schematic_trace",
-      "schematic_trace_id": "schematic_trace_21",
-      "source_trace_id": "source_trace_21",
-      "edges": [
-        {
-          "from": {
-            "x": 1.125,
-            "y": 5.25
-          },
-          "to": {
-            "x": 1.385,
-            "y": 5.25
-          },
-          "from_schematic_port_id": "schematic_port_23"
-        }
-      ]
-    },
-    {
-      "type": "source_trace",
-      "connected_source_port_ids": [
-        "source_port_25"
-      ],
-      "connected_source_net_ids": [
-        "net_8"
-      ],
-      "source_trace_id": "source_trace_22"
-    },
-    {
-      "type": "schematic_net_label",
-      "source_net_id": "net_8",
-      "text": "PWRIN",
-      "anchor_side": "left",
-      "center": {
-        "x": -10.75,
-        "y": -1.75
-      }
-    },
-    {
-      "type": "schematic_trace",
-      "schematic_trace_id": "schematic_trace_22",
-      "source_trace_id": "source_trace_22",
-      "edges": [
-        {
-          "from": {
-            "x": -11.25,
-            "y": -1.75
-          },
-          "to": {
-            "x": -10.95,
-            "y": -1.75
-          },
-          "from_schematic_port_id": "schematic_port_25"
-        }
-      ]
-    },
-    {
-      "type": "source_trace",
-      "connected_source_port_ids": [
-        "source_port_24"
-      ],
-      "connected_source_net_ids": [
-        "net_0"
-      ],
-      "source_trace_id": "source_trace_23"
-    },
-    {
-      "type": "schematic_net_label",
-      "source_net_id": "net_0",
-      "text": "GND",
-      "anchor_side": "left",
-      "center": {
-        "x": -10.75,
-        "y": -2.25
-      }
-    },
-    {
-      "type": "schematic_trace",
-      "schematic_trace_id": "schematic_trace_23",
-      "source_trace_id": "source_trace_23",
-      "edges": [
-        {
-          "from": {
-            "x": -11.25,
-            "y": -2.25
-          },
-          "to": {
-            "x": -10.95,
-            "y": -2.25
-          },
-          "from_schematic_port_id": "schematic_port_24"
-        }
-      ]
-    },
-    {
-      "type": "source_trace",
-      "connected_source_port_ids": [
-        "source_port_26"
-      ],
-      "connected_source_net_ids": [
-        "net_8"
-      ],
-      "source_trace_id": "source_trace_24"
-    },
-    {
-      "type": "schematic_net_label",
-      "source_net_id": "net_8",
-      "text": "PWRIN",
-      "anchor_side": "left",
-      "center": {
-        "x": -10.75,
-        "y": 1.75
-      }
-    },
-    {
-      "type": "schematic_trace",
-      "schematic_trace_id": "schematic_trace_24",
-      "source_trace_id": "source_trace_24",
-      "edges": [
-        {
-          "from": {
-            "x": -11.25,
-            "y": 1.75
-          },
-          "to": {
-            "x": -10.95,
-            "y": 1.75
-          },
-          "from_schematic_port_id": "schematic_port_26"
-        }
-      ]
-    },
-    {
-      "type": "source_trace",
-      "connected_source_port_ids": [
-        "source_port_27"
-      ],
-      "connected_source_net_ids": [
-        "net_9"
-      ],
-      "source_trace_id": "source_trace_25"
-    },
-    {
-      "type": "schematic_net_label",
-      "source_net_id": "net_9",
-      "text": "VCC",
-      "anchor_side": "left",
-      "center": {
-        "x": -10.75,
-        "y": 2.25
-      }
-    },
-    {
-      "type": "schematic_trace",
-      "schematic_trace_id": "schematic_trace_25",
-      "source_trace_id": "source_trace_25",
-      "edges": [
-        {
-          "from": {
-            "x": -11.25,
-            "y": 2.25
-          },
-          "to": {
-            "x": -10.95,
-            "y": 2.25
-          },
-          "from_schematic_port_id": "schematic_port_27"
-        }
-      ]
-    },
-    {
-      "type": "source_trace",
-      "connected_source_port_ids": [
-        "source_port_28"
-      ],
-      "connected_source_net_ids": [
-        "net_2"
-      ],
-      "source_trace_id": "source_trace_26"
-    },
-    {
-      "type": "schematic_net_label",
-      "source_net_id": "net_2",
-      "text": "PWMB",
-      "anchor_side": "left",
-      "center": {
-        "x": -10.75,
-        "y": 2.75
-      }
-    },
-    {
-      "type": "schematic_trace",
-      "schematic_trace_id": "schematic_trace_26",
-      "source_trace_id": "source_trace_26",
-      "edges": [
-        {
-          "from": {
-            "x": -11.25,
-            "y": 2.75
-          },
-          "to": {
-            "x": -10.95,
-            "y": 2.75
-          },
-          "from_schematic_port_id": "schematic_port_28"
-        }
-      ]
-    },
-    {
-      "type": "source_trace",
-      "connected_source_port_ids": [
-        "source_port_30"
-      ],
-      "connected_source_net_ids": [
-        "net_3"
-      ],
-      "source_trace_id": "source_trace_27"
-    },
-    {
-      "type": "schematic_net_label",
-      "source_net_id": "net_3",
-      "text": "BIN2",
-      "anchor_side": "left",
-      "center": {
-        "x": -10.75,
-        "y": 3.75
-      }
-    },
-    {
-      "type": "schematic_trace",
-      "schematic_trace_id": "schematic_trace_27",
-      "source_trace_id": "source_trace_27",
-      "edges": [
-        {
-          "from": {
-            "x": -11.25,
-            "y": 3.75
-          },
-          "to": {
-            "x": -10.95,
-            "y": 3.75
-          },
-          "from_schematic_port_id": "schematic_port_30"
-        }
-      ]
-    },
-    {
-      "type": "source_trace",
-      "connected_source_port_ids": [
-        "source_port_31"
-      ],
-      "connected_source_net_ids": [
-        "net_4"
-      ],
-      "source_trace_id": "source_trace_28"
-    },
-    {
-      "type": "schematic_net_label",
-      "source_net_id": "net_4",
-      "text": "BIN1",
-      "anchor_side": "left",
-      "center": {
-        "x": -10.75,
-        "y": 4.25
-      }
-    },
-    {
-      "type": "schematic_trace",
-      "schematic_trace_id": "schematic_trace_28",
-      "source_trace_id": "source_trace_28",
-      "edges": [
-        {
-          "from": {
-            "x": -11.25,
-            "y": 4.25
-          },
-          "to": {
-            "x": -10.95,
-            "y": 4.25
-          },
-          "from_schematic_port_id": "schematic_port_31"
-        }
-      ]
-    },
-    {
-      "type": "source_trace",
-      "connected_source_port_ids": [
-        "source_port_32"
-      ],
-      "connected_source_net_ids": [
-        "net_10"
-      ],
-      "source_trace_id": "source_trace_29"
-    },
-    {
-      "type": "schematic_net_label",
-      "source_net_id": "net_10",
-      "text": "STBY",
-      "anchor_side": "left",
-      "center": {
-        "x": -10.75,
-        "y": 4.75
-      }
-    },
-    {
-      "type": "schematic_trace",
-      "schematic_trace_id": "schematic_trace_29",
-      "source_trace_id": "source_trace_29",
-      "edges": [
-        {
-          "from": {
-            "x": -11.25,
-            "y": 4.75
-          },
-          "to": {
-            "x": -10.95,
-            "y": 4.75
-          },
-          "from_schematic_port_id": "schematic_port_32"
-        }
-      ]
-    },
-    {
-      "type": "source_trace",
-      "connected_source_port_ids": [
-        "source_port_33"
-      ],
-      "connected_source_net_ids": [
-        "net_5"
-      ],
-      "source_trace_id": "source_trace_30"
-    },
-    {
-      "type": "schematic_net_label",
-      "source_net_id": "net_5",
-      "text": "AIN1",
-      "anchor_side": "left",
-      "center": {
-        "x": -10.75,
-        "y": 5.25
-      }
-    },
-    {
-      "type": "schematic_trace",
-      "schematic_trace_id": "schematic_trace_30",
-      "source_trace_id": "source_trace_30",
-      "edges": [
-        {
-          "from": {
-            "x": -11.25,
-            "y": 5.25
-          },
-          "to": {
-            "x": -10.95,
-            "y": 5.25
-          },
-          "from_schematic_port_id": "schematic_port_33"
-        }
-      ]
-    },
-    {
-      "type": "source_trace",
-      "connected_source_port_ids": [
-        "source_port_34"
-      ],
-      "connected_source_net_ids": [
-        "net_6"
-      ],
-      "source_trace_id": "source_trace_31"
-    },
-    {
-      "type": "schematic_net_label",
-      "source_net_id": "net_6",
-      "text": "AIN2",
-      "anchor_side": "left",
-      "center": {
-        "x": -10.75,
-        "y": 5.75
-      }
-    },
-    {
-      "type": "schematic_trace",
-      "schematic_trace_id": "schematic_trace_31",
-      "source_trace_id": "source_trace_31",
-      "edges": [
-        {
-          "from": {
-            "x": -11.25,
-            "y": 5.75
-          },
-          "to": {
-            "x": -10.95,
-            "y": 5.75
-          },
-          "from_schematic_port_id": "schematic_port_34"
-        }
-      ]
-    },
-    {
-      "type": "source_trace",
-      "connected_source_port_ids": [
-        "source_port_35"
-      ],
-      "connected_source_net_ids": [
-        "net_7"
-      ],
-      "source_trace_id": "source_trace_32"
-    },
-    {
-      "type": "schematic_net_label",
-      "source_net_id": "net_7",
-      "text": "PWMA",
-      "anchor_side": "left",
-      "center": {
-        "x": -10.75,
-        "y": 6.25
-      }
-    },
-    {
-      "type": "schematic_trace",
-      "schematic_trace_id": "schematic_trace_32",
-      "source_trace_id": "source_trace_32",
-      "edges": [
-        {
-          "from": {
-            "x": -11.25,
-            "y": 6.25
-          },
-          "to": {
-            "x": -10.95,
-            "y": 6.25
-          },
-          "from_schematic_port_id": "schematic_port_35"
-        }
-      ]
-    },
-    {
-      "type": "source_trace",
-      "connected_source_port_ids": [
-        "source_port_38"
-      ],
-      "connected_source_net_ids": [
-        "net_0"
-      ],
-      "source_trace_id": "source_trace_33"
-    },
-    {
-      "type": "schematic_net_label",
-      "source_net_id": "net_0",
-      "text": "GND",
-      "anchor_side": "right",
-      "center": {
-        "x": 3.75,
-        "y": 0
-      }
-    },
-    {
-      "type": "schematic_trace",
-      "schematic_trace_id": "schematic_trace_33",
-      "source_trace_id": "source_trace_33",
-      "edges": [
-        {
-          "from": {
-            "x": 4.25,
-            "y": 0
-          },
-          "to": {
-            "x": 3.95,
-            "y": 0
-          },
-          "from_schematic_port_id": "schematic_port_38"
-        }
-      ]
-    },
-    {
-      "type": "source_trace",
-      "source_trace_id": "source_trace_34",
-      "connected_source_port_ids": [
-        "source_port_41",
-        "source_port_4"
-      ]
-    },
-    {
-      "type": "schematic_trace",
-      "source_trace_id": "source_trace_34",
-      "schematic_trace_id": "schematic_trace_34",
-      "edges": [
-        {
-          "from": {
-            "x": -1.2999999999999998,
-            "y": 0
-          },
-          "to": {
-            "x": -1.2999999999999998,
-            "y": -0.19999999999999996
-          }
-        },
-        {
-          "from": {
-            "x": -1.2999999999999998,
-            "y": -0.19999999999999996
-          },
-          "to": {
-            "x": -2.6999999999999997,
-            "y": -0.19999999999999996
-          }
-        },
-        {
-          "from": {
-            "x": -2.6999999999999997,
-            "y": -0.19999999999999996
-          },
-          "to": {
-            "x": -2.6999999999999997,
-            "y": -0.6000000000000001
-          }
-        },
-        {
-          "from": {
-            "x": -2.6999999999999997,
-            "y": -0.6000000000000001
-          },
-          "to": {
-            "x": -5,
-            "y": -0.6000000000000001
-          }
-        },
-        {
-          "from": {
-            "x": -5,
-            "y": -0.5,
-            "ti": 0
-          },
-          "to": {
-            "x": -5,
-            "y": -0.6000000000000001
-          }
-        },
-        {
-          "from": {
-            "x": -1.125,
-            "y": 0,
-            "ti": 1
-          },
-          "to": {
-            "x": -1.2999999999999998,
-            "y": 0
-          }
-        }
-      ]
-    },
-    {
-      "type": "pcb_trace",
-      "pcb_trace_id": "pcb_trace_9",
-      "source_trace_id": "source_trace_34",
-      "route": []
-    },
-    {
-      "type": "source_trace",
-      "source_trace_id": "source_trace_35",
-      "connected_source_port_ids": [
-        "source_port_42",
-        "source_port_0"
-      ]
-    },
-    {
-      "type": "schematic_trace",
-      "source_trace_id": "source_trace_35",
-      "schematic_trace_id": "schematic_trace_35",
-      "edges": [
-        {
-          "from": {
-            "x": -1.2999999999999998,
-            "y": 3
-          },
-          "to": {
-            "x": -1.2999999999999998,
-            "y": 2.8
-          }
-        },
-        {
-          "from": {
-            "x": -1.2999999999999998,
-            "y": 2.8
-          },
-          "to": {
-            "x": -5,
-            "y": 2.8
-          }
-        },
-        {
-          "from": {
-            "x": -5,
-            "y": 2.8
-          },
-          "to": {
-            "x": -5,
-            "y": 0.7
-          }
-        },
-        {
-          "from": {
-            "x": -5,
-            "y": 0.5,
-            "ti": 0
-          },
-          "to": {
-            "x": -5,
-            "y": 0.7
-          }
-        },
-        {
-          "from": {
-            "x": -1.125,
-            "y": 3,
-            "ti": 1
-          },
-          "to": {
-            "x": -1.2999999999999998,
-            "y": 3
-          }
-        }
-      ]
-    },
-    {
-      "type": "pcb_trace",
-      "pcb_trace_id": "pcb_trace_10",
-      "source_trace_id": "source_trace_35",
-      "route": [
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 2.4,
-          "y": 7.800000000000001
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 2.4,
-          "y": 6.800000000000001
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 2.3999999999999995,
-          "y": 6.800000000000001
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 1.1999999999999993,
-          "y": 5.6
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 1.1999999999999993,
-          "y": 5.200000000000001
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 0.7999999999999998,
-          "y": 4.800000000000001
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 0.7999999999999998,
-          "y": 3.5999999999999996
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 0.39999999999999947,
-          "y": 3.200000000000001
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 0.39999999999999947,
-          "y": 0
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 0,
-          "y": -0.40000000000000036
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 0,
-          "y": -1.2000000000000002
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": -0.40000000000000036,
-          "y": -1.5999999999999996
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": -0.40000000000000036,
-          "y": -2
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": -0.40000000000000036,
-          "y": -2
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": -0.8000000000000007,
-          "y": -2.4000000000000004
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": -0.8000000000000007,
-          "y": -2.4000000000000004
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 0.39999999999999947,
-          "y": -1.2000000000000002
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 0.5999999999999996,
-          "y": -1.2000000000000002
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 0.7999999999999998,
-          "y": -1
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 1,
-          "y": -1
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 1.7999999999999998,
-          "y": -0.20000000000000018
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 2,
-          "y": -0.20000000000000018
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 3.5999999999999996,
-          "y": 1.4000000000000004
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 5.199999999999999,
-          "y": 1.4000000000000004
-        }
-      ]
-    },
-    {
-      "type": "source_trace",
-      "source_trace_id": "source_trace_36",
-      "connected_source_port_ids": [
-        "source_port_43",
-        "source_port_0"
-      ]
-    },
-    {
-      "type": "schematic_trace",
-      "source_trace_id": "source_trace_36",
-      "schematic_trace_id": "schematic_trace_36",
-      "edges": [
-        {
-          "from": {
-            "x": -1.2999999999999998,
-            "y": 3.0000000000000004
-          },
-          "to": {
-            "x": -1.2999999999999998,
-            "y": 2.8000000000000003
-          }
-        },
-        {
-          "from": {
-            "x": -1.2999999999999998,
-            "y": 2.8000000000000003
-          },
-          "to": {
-            "x": -4,
-            "y": 2.8000000000000003
-          }
-        },
-        {
-          "from": {
-            "x": -4,
-            "y": 2.8000000000000003
-          },
-          "to": {
-            "x": -4,
-            "y": 1.6
-          }
-        },
-        {
-          "from": {
-            "x": -4,
-            "y": 1.5,
-            "ti": 0
-          },
-          "to": {
-            "x": -4,
-            "y": 1.6
-          }
-        },
-        {
-          "from": {
-            "x": -1.125,
-            "y": 3,
-            "ti": 1
-          },
-          "to": {
-            "x": -1.2999999999999998,
-            "y": 3.0000000000000004
-          }
-        }
-      ]
-    },
-    {
-      "type": "pcb_trace",
-      "pcb_trace_id": "pcb_trace_11",
-      "source_trace_id": "source_trace_36",
-      "route": [
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 1.2000000000000002,
-          "y": -3.6000000000000005
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 0.7999999999999998,
-          "y": -3.6000000000000005
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 0.40000000000000036,
-          "y": -3.2
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 0,
-          "y": -3.2
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": -0.20000000000000018,
-          "y": -3
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": -0.40000000000000036,
-          "y": -3
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": -0.40000000000000036,
-          "y": -3
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": -0.6000000000000005,
-          "y": -2.8
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": -0.6000000000000005,
-          "y": -2.5999999999999996
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": -0.8000000000000007,
-          "y": -2.3999999999999995
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": -0.8000000000000007,
-          "y": -2.4000000000000004
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 0.39999999999999947,
-          "y": -1.2000000000000002
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 0.5999999999999996,
-          "y": -1.2000000000000002
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 0.7999999999999998,
-          "y": -1
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 1,
-          "y": -1
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 1.7999999999999998,
-          "y": -0.20000000000000018
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 2,
-          "y": -0.20000000000000018
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 3.5999999999999996,
-          "y": 1.4000000000000004
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 5.199999999999999,
-          "y": 1.4000000000000004
-        }
-      ]
-    },
-    {
-      "type": "source_trace",
-      "connected_source_port_ids": [
-        "source_port_44"
-      ],
-      "connected_source_net_ids": [
-        "net_0"
-      ],
-      "source_trace_id": "source_trace_37"
-    },
-    {
-      "type": "schematic_net_label",
-      "source_net_id": "net_0",
-      "text": "GND",
-      "anchor_side": "top",
-      "center": {
-        "x": -4,
-        "y": 0
-      }
-    },
-    {
-      "type": "schematic_trace",
-      "schematic_trace_id": "schematic_trace_37",
-      "source_trace_id": "source_trace_37",
-      "edges": [
-        {
-          "from": {
-            "x": -4,
-            "y": 0.5
-          },
-          "to": {
-            "x": -4,
-            "y": 0.2
-          },
-          "from_schematic_port_id": "schematic_port_44"
-        }
-      ]
-    },
-    {
-      "type": "source_trace",
-      "connected_source_port_ids": [
-        "source_port_45"
-      ],
-      "connected_source_net_ids": [
-        "net_1"
-      ],
-      "source_trace_id": "source_trace_38"
-    },
-    {
-      "type": "schematic_net_label",
-      "source_net_id": "net_1",
-      "text": "VMOTOR",
-      "anchor_side": "bottom",
-      "center": {
-        "x": -6,
-        "y": -1
-      }
-    },
-    {
-      "type": "schematic_trace",
-      "schematic_trace_id": "schematic_trace_38",
-      "source_trace_id": "source_trace_38",
-      "edges": [
-        {
-          "from": {
-            "x": -6,
-            "y": -1.5
-          },
-          "to": {
-            "x": -6,
-            "y": -1.2
-          },
-          "from_schematic_port_id": "schematic_port_45"
-        }
-      ]
-    },
-    {
-      "type": "source_trace",
-      "connected_source_port_ids": [
-        "source_port_46"
-      ],
-      "connected_source_net_ids": [
-        "net_0"
-      ],
-      "source_trace_id": "source_trace_39"
-    },
-    {
-      "type": "schematic_net_label",
-      "source_net_id": "net_0",
-      "text": "GND",
-      "anchor_side": "top",
-      "center": {
-        "x": -6,
-        "y": -3
-      }
-    },
-    {
-      "type": "schematic_trace",
-      "schematic_trace_id": "schematic_trace_39",
-      "source_trace_id": "source_trace_39",
-      "edges": [
-        {
-          "from": {
-            "x": -6,
-            "y": -2.5
-          },
-          "to": {
-            "x": -6,
-            "y": -2.8
-          },
-          "from_schematic_port_id": "schematic_port_46"
-        }
-      ]
-    },
-    {
-      "type": "source_trace",
-      "source_trace_id": "source_trace_40",
-      "connected_source_port_ids": [
-        "source_port_48",
-        "source_port_46"
-      ]
-    },
-    {
-      "type": "schematic_trace",
-      "source_trace_id": "source_trace_40",
-      "schematic_trace_id": "schematic_trace_40",
-      "edges": [
-        {
-          "from": {
-            "x": -6,
-            "y": -2.6000000000000005
-          },
-          "to": {
-            "x": -6,
-            "y": -2.9000000000000004
-          }
-        },
-        {
-          "from": {
-            "x": -6,
-            "y": -2.9000000000000004
-          },
-          "to": {
-            "x": -8,
-            "y": -2.9000000000000004
-          }
-        },
-        {
-          "from": {
-            "x": -8,
-            "y": -2.75,
-            "ti": 0
-          },
-          "to": {
-            "x": -8,
-            "y": -2.9000000000000004
-          }
-        },
-        {
-          "from": {
-            "x": -6,
-            "y": -2.5,
-            "ti": 1
-          },
-          "to": {
-            "x": -6,
-            "y": -2.6000000000000005
-          }
-        }
-      ]
-    },
-    {
-      "type": "pcb_trace",
-      "pcb_trace_id": "pcb_trace_12",
-      "source_trace_id": "source_trace_40",
-      "route": [
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 10.600000000000001,
-          "y": -8.200000000000001
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 10.600000000000001,
-          "y": -6.800000000000001
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 10.4,
-          "y": -6.6000000000000005
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 10.4,
-          "y": 6.4
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 10.4,
-          "y": 6.400000000000002
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 12,
-          "y": 8
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 12,
-          "y": 10
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 11.600000000000001,
-          "y": 10.400000000000002
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 11.200000000000001,
-          "y": 10.400000000000002
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 11.2,
-          "y": 10.4
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 11.2,
-          "y": 10.8
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 11,
-          "y": 11
-        }
-      ]
-    },
-    {
-      "type": "source_trace",
-      "source_trace_id": "source_trace_41",
-      "connected_source_port_ids": [
-        "source_port_49",
-        "source_port_45"
-      ]
-    },
-    {
-      "type": "schematic_trace",
-      "source_trace_id": "source_trace_41",
-      "schematic_trace_id": "schematic_trace_41",
-      "edges": [
-        {
-          "from": {
-            "x": -6,
-            "y": -1.4
-          },
-          "to": {
-            "x": -6,
-            "y": -1.5999999999999999
-          }
-        },
-        {
-          "from": {
-            "x": -6,
-            "y": -1.5999999999999999
-          },
-          "to": {
-            "x": -6.699999999999999,
-            "y": -1.5999999999999999
-          }
-        },
-        {
-          "from": {
-            "x": -6.699999999999999,
-            "y": -1.5999999999999999
-          },
-          "to": {
-            "x": -6.699999999999999,
-            "y": -2
-          }
-        },
-        {
-          "from": {
-            "x": -6.699999999999999,
-            "y": -2
-          },
-          "to": {
-            "x": -7.1,
-            "y": -2
-          }
-        },
-        {
-          "from": {
-            "x": -7.25,
-            "y": -2,
-            "ti": 0
-          },
-          "to": {
-            "x": -7.1,
-            "y": -2
-          }
-        },
-        {
-          "from": {
-            "x": -6,
-            "y": -1.5,
-            "ti": 1
-          },
-          "to": {
-            "x": -6,
-            "y": -1.4
-          }
-        }
-      ]
-    },
-    {
-      "type": "pcb_trace",
-      "pcb_trace_id": "pcb_trace_13",
-      "source_trace_id": "source_trace_41",
-      "route": [
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 8.8,
-          "y": -8.200000000000001
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 8.8,
-          "y": 0
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 8.8,
-          "y": 0
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 9.200000000000001,
-          "y": 0.40000000000000036
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 9.200000000000001,
-          "y": 4.800000000000001
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 10.400000000000002,
-          "y": 6
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 10.400000000000002,
-          "y": 8.8
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 10.4,
-          "y": 8.8
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 10.8,
-          "y": 8.8
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 11,
-          "y": 9
-        }
-      ]
-    },
-    {
-      "type": "source_trace",
-      "source_trace_id": "source_trace_42",
-      "connected_source_port_ids": [
-        "source_port_47",
-        "source_port_25"
-      ]
-    },
-    {
-      "type": "schematic_trace",
-      "source_trace_id": "source_trace_42",
-      "schematic_trace_id": "schematic_trace_42",
-      "edges": [
-        {
-          "from": {
-            "x": -8.9,
-            "y": -2
-          },
-          "to": {
-            "x": -11.3,
-            "y": -2
-          }
-        },
-        {
-          "from": {
-            "x": -11.3,
-            "y": -2
-          },
-          "to": {
-            "x": -11.3,
-            "y": -1.7
-          }
-        },
-        {
-          "from": {
-            "x": -8.75,
-            "y": -2,
-            "ti": 0
-          },
-          "to": {
-            "x": -8.9,
-            "y": -2
-          }
-        },
-        {
-          "from": {
-            "x": -11.25,
-            "y": -1.75,
-            "ti": 1
-          },
-          "to": {
-            "x": -11.3,
-            "y": -1.7
-          }
-        }
-      ]
-    },
-    {
-      "type": "pcb_trace",
-      "pcb_trace_id": "pcb_trace_14",
-      "source_trace_id": "source_trace_42",
-      "route": [
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 0.40000000000000036,
-          "y": -10.8
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 0.40000000000000036,
-          "y": -10.4
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 0,
-          "y": -10
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 0,
-          "y": -10
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 7,
-          "y": -3
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 7,
-          "y": 2
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 8,
-          "y": 3
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 8,
-          "y": 6
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 9,
-          "y": 7
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 9,
-          "y": 7
-        },
-        {
-          "route_type": "wire",
-          "layer": "top",
-          "width": 0.2,
-          "x": 9,
-          "y": 10
-        }
-      ]
-    },
-    {
-      "type": "pcb_board",
-      "center": {
-        "x": 0,
-        "y": 0
-      },
-      "width": 40,
-      "height": 40
+  {
+    "type": "source_component",
+    "source_component_id": "simple_bug_0",
+    "name": "U2",
+    "supplier_part_numbers": {},
+    "ftype": "simple_bug",
+    "schPortArrangement": {
+      "leftSize": 4,
+      "rightSize": 4,
+      "left_size": 4,
+      "right_size": 4
+    },
+    "pinLabels": {
+      "1": "GND",
+      "2": "VBUS",
+      "3": "D-",
+      "4": "D+"
+    },
+    "sch_port_arrangement": {
+      "leftSize": 4,
+      "rightSize": 4,
+      "left_size": 4,
+      "right_size": 4
+    },
+    "pin_labels": {
+      "1": "GND",
+      "2": "VBUS",
+      "3": "D-",
+      "4": "D+"
     }
-  ]
+  },
+  {
+    "type": "schematic_component",
+    "source_component_id": "simple_bug_0",
+    "schematic_component_id": "schematic_component_simple_bug_0",
+    "rotation": 0,
+    "size": {
+      "width": 1,
+      "height": 2
+    },
+    "center": {
+      "x": 0,
+      "y": 0
+    },
+    "port_labels": {
+      "1": "GND",
+      "2": "VBUS",
+      "3": "D-",
+      "4": "D+"
+    },
+    "port_arrangement": {
+      "left_size": 4,
+      "right_size": 4
+    }
+  },
+  {
+    "type": "source_port",
+    "name": "GND",
+    "source_port_id": "source_port_0",
+    "source_component_id": "simple_bug_0",
+    "pin_number": 1,
+    "port_hints": [
+      "GND",
+      "1"
+    ]
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_0",
+    "source_port_id": "source_port_0",
+    "center": {
+      "x": -0.75,
+      "y": 0.75
+    },
+    "facing_direction": "left",
+    "schematic_component_id": "schematic_component_simple_bug_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_port_id": "schematic_port_0",
+    "schematic_text_id": "schematic_text_8",
+    "text": "1",
+    "anchor": "center",
+    "rotation": 0,
+    "position": {
+      "x": -0.6262563132923542,
+      "y": 0.6262563132923542
+    },
+    "schematic_component_id": "schematic_component_simple_bug_0"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_0",
+    "source_port_id": "source_port_0",
+    "pcb_component_id": "pcb_component_simple_bug_0",
+    "x": -6.4542506265664175,
+    "y": 4.578192982456141,
+    "layers": [
+      "top"
+    ]
+  },
+  {
+    "type": "source_port",
+    "name": "VBUS",
+    "source_port_id": "source_port_1",
+    "source_component_id": "simple_bug_0",
+    "pin_number": 2,
+    "port_hints": [
+      "VBUS",
+      "2"
+    ]
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_1",
+    "source_port_id": "source_port_1",
+    "center": {
+      "x": -0.75,
+      "y": 0.25
+    },
+    "facing_direction": "left",
+    "schematic_component_id": "schematic_component_simple_bug_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_port_id": "schematic_port_1",
+    "schematic_text_id": "schematic_text_9",
+    "text": "2",
+    "anchor": "center",
+    "rotation": 0,
+    "position": {
+      "x": -0.6262563132923542,
+      "y": 0.12625631329235418
+    },
+    "schematic_component_id": "schematic_component_simple_bug_0"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_1",
+    "source_port_id": "source_port_1",
+    "pcb_component_id": "pcb_component_simple_bug_0",
+    "x": -6.4542506265664175,
+    "y": 3.308192982456141,
+    "layers": [
+      "top"
+    ]
+  },
+  {
+    "type": "source_port",
+    "name": "D-",
+    "source_port_id": "source_port_2",
+    "source_component_id": "simple_bug_0",
+    "pin_number": 3,
+    "port_hints": [
+      "D-",
+      "3"
+    ]
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_2",
+    "source_port_id": "source_port_2",
+    "center": {
+      "x": -0.75,
+      "y": -0.25
+    },
+    "facing_direction": "left",
+    "schematic_component_id": "schematic_component_simple_bug_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_port_id": "schematic_port_2",
+    "schematic_text_id": "schematic_text_10",
+    "text": "3",
+    "anchor": "center",
+    "rotation": 0,
+    "position": {
+      "x": -0.6262563132923542,
+      "y": -0.3737436867076458
+    },
+    "schematic_component_id": "schematic_component_simple_bug_0"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_2",
+    "source_port_id": "source_port_2",
+    "pcb_component_id": "pcb_component_simple_bug_0",
+    "x": -6.4542506265664175,
+    "y": 2.038192982456141,
+    "layers": [
+      "top"
+    ]
+  },
+  {
+    "type": "source_port",
+    "name": "D+",
+    "source_port_id": "source_port_3",
+    "source_component_id": "simple_bug_0",
+    "pin_number": 4,
+    "port_hints": [
+      "D+",
+      "4"
+    ]
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_3",
+    "source_port_id": "source_port_3",
+    "center": {
+      "x": -0.75,
+      "y": -0.75
+    },
+    "facing_direction": "left",
+    "schematic_component_id": "schematic_component_simple_bug_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_port_id": "schematic_port_3",
+    "schematic_text_id": "schematic_text_11",
+    "text": "4",
+    "anchor": "center",
+    "rotation": 0,
+    "position": {
+      "x": -0.6262563132923542,
+      "y": -0.8737436867076458
+    },
+    "schematic_component_id": "schematic_component_simple_bug_0"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_3",
+    "source_port_id": "source_port_3",
+    "pcb_component_id": "pcb_component_simple_bug_0",
+    "x": -6.4542506265664175,
+    "y": 0.7681929824561409,
+    "layers": [
+      "top"
+    ]
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_4",
+    "source_component_id": "simple_bug_0",
+    "pin_number": 5,
+    "port_hints": [
+      "5"
+    ]
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_4",
+    "source_port_id": "source_port_4",
+    "center": {
+      "x": 0.75,
+      "y": -0.75
+    },
+    "facing_direction": "right",
+    "schematic_component_id": "schematic_component_simple_bug_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_port_id": "schematic_port_4",
+    "schematic_text_id": "schematic_text_12",
+    "text": "5",
+    "anchor": "center",
+    "rotation": 0,
+    "position": {
+      "x": 0.6262563132923542,
+      "y": -0.8737436867076458
+    },
+    "schematic_component_id": "schematic_component_simple_bug_0"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_4",
+    "source_port_id": "source_port_4",
+    "pcb_component_id": "pcb_component_simple_bug_0",
+    "x": -6.4542506265664175,
+    "y": -0.5018070175438591,
+    "layers": [
+      "top"
+    ]
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_5",
+    "source_component_id": "simple_bug_0",
+    "pin_number": 6,
+    "port_hints": [
+      "6"
+    ]
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_5",
+    "source_port_id": "source_port_5",
+    "center": {
+      "x": 0.75,
+      "y": -0.25
+    },
+    "facing_direction": "right",
+    "schematic_component_id": "schematic_component_simple_bug_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_port_id": "schematic_port_5",
+    "schematic_text_id": "schematic_text_13",
+    "text": "6",
+    "anchor": "center",
+    "rotation": 0,
+    "position": {
+      "x": 0.6262563132923542,
+      "y": -0.3737436867076458
+    },
+    "schematic_component_id": "schematic_component_simple_bug_0"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_5",
+    "source_port_id": "source_port_5",
+    "pcb_component_id": "pcb_component_simple_bug_0",
+    "x": -6.4542506265664175,
+    "y": -1.7718070175438587,
+    "layers": [
+      "top"
+    ]
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_6",
+    "source_component_id": "simple_bug_0",
+    "pin_number": 7,
+    "port_hints": [
+      "7"
+    ]
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_6",
+    "source_port_id": "source_port_6",
+    "center": {
+      "x": 0.75,
+      "y": 0.25
+    },
+    "facing_direction": "right",
+    "schematic_component_id": "schematic_component_simple_bug_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_port_id": "schematic_port_6",
+    "schematic_text_id": "schematic_text_14",
+    "text": "7",
+    "anchor": "center",
+    "rotation": 0,
+    "position": {
+      "x": 0.6262563132923542,
+      "y": 0.12625631329235418
+    },
+    "schematic_component_id": "schematic_component_simple_bug_0"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_6",
+    "source_port_id": "source_port_6",
+    "pcb_component_id": "pcb_component_simple_bug_0",
+    "x": -6.4542506265664175,
+    "y": -3.041807017543859,
+    "layers": [
+      "top"
+    ]
+  },
+  {
+    "type": "source_port",
+    "source_port_id": "source_port_7",
+    "source_component_id": "simple_bug_0",
+    "pin_number": 8,
+    "port_hints": [
+      "8"
+    ]
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_7",
+    "source_port_id": "source_port_7",
+    "center": {
+      "x": 0.75,
+      "y": 0.75
+    },
+    "facing_direction": "right",
+    "schematic_component_id": "schematic_component_simple_bug_0"
+  },
+  {
+    "type": "schematic_text",
+    "schematic_port_id": "schematic_port_7",
+    "schematic_text_id": "schematic_text_15",
+    "text": "8",
+    "anchor": "center",
+    "rotation": 0,
+    "position": {
+      "x": 0.6262563132923542,
+      "y": 0.6262563132923542
+    },
+    "schematic_component_id": "schematic_component_simple_bug_0"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_7",
+    "source_port_id": "source_port_7",
+    "pcb_component_id": "pcb_component_simple_bug_0",
+    "x": -6.4542506265664175,
+    "y": -4.31180701754386,
+    "layers": [
+      "top"
+    ]
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_0",
+    "schematic_component_id": "schematic_component_simple_bug_0",
+    "text": "GND",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -0.35,
+      "y": 0.75
+    }
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_1",
+    "schematic_component_id": "schematic_component_simple_bug_0",
+    "text": "VBUS",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -0.35,
+      "y": 0.25
+    }
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_2",
+    "schematic_component_id": "schematic_component_simple_bug_0",
+    "text": "D-",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -0.35,
+      "y": -0.25
+    }
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_3",
+    "schematic_component_id": "schematic_component_simple_bug_0",
+    "text": "D+",
+    "anchor": "left",
+    "rotation": 0,
+    "position": {
+      "x": -0.35,
+      "y": -0.75
+    }
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_4",
+    "schematic_component_id": "schematic_component_simple_bug_0",
+    "anchor": "right",
+    "rotation": 0,
+    "position": {
+      "x": 0.35,
+      "y": -0.75
+    }
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_5",
+    "schematic_component_id": "schematic_component_simple_bug_0",
+    "anchor": "right",
+    "rotation": 0,
+    "position": {
+      "x": 0.35,
+      "y": -0.25
+    }
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_6",
+    "schematic_component_id": "schematic_component_simple_bug_0",
+    "anchor": "right",
+    "rotation": 0,
+    "position": {
+      "x": 0.35,
+      "y": 0.25
+    }
+  },
+  {
+    "type": "schematic_text",
+    "schematic_text_id": "schematic_text_7",
+    "schematic_component_id": "schematic_component_simple_bug_0",
+    "anchor": "right",
+    "rotation": 0,
+    "position": {
+      "x": 0.35,
+      "y": 0.75
+    }
+  },
+  {
+    "type": "pcb_component",
+    "source_component_id": "simple_bug_0",
+    "pcb_component_id": "pcb_component_simple_bug_0",
+    "layer": "top",
+    "center": {
+      "x": -5.004250626566417,
+      "y": 0.13319298245614064
+    },
+    "rotation": 0,
+    "width": 3.9,
+    "height": 9.49
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_0",
+    "shape": "rect",
+    "x": -6.4542506265664175,
+    "y": 4.578192982456141,
+    "width": 1,
+    "height": 0.6,
+    "layer": "top",
+    "pcb_component_id": "pcb_component_simple_bug_0",
+    "port_hints": [
+      "1"
+    ],
+    "pcb_port_id": "pcb_port_0"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_2",
+    "shape": "rect",
+    "x": -6.4542506265664175,
+    "y": 3.308192982456141,
+    "width": 1,
+    "height": 0.6,
+    "layer": "top",
+    "pcb_component_id": "pcb_component_simple_bug_0",
+    "port_hints": [
+      "2"
+    ],
+    "pcb_port_id": "pcb_port_1"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_4",
+    "shape": "rect",
+    "x": -6.4542506265664175,
+    "y": 2.038192982456141,
+    "width": 1,
+    "height": 0.6,
+    "layer": "top",
+    "pcb_component_id": "pcb_component_simple_bug_0",
+    "port_hints": [
+      "3"
+    ],
+    "pcb_port_id": "pcb_port_2"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_5",
+    "shape": "rect",
+    "x": -6.4542506265664175,
+    "y": 0.7681929824561409,
+    "width": 1,
+    "height": 0.6,
+    "layer": "top",
+    "pcb_component_id": "pcb_component_simple_bug_0",
+    "port_hints": [
+      "4"
+    ],
+    "pcb_port_id": "pcb_port_3"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_6",
+    "shape": "rect",
+    "x": -6.4542506265664175,
+    "y": -0.5018070175438591,
+    "width": 1,
+    "height": 0.6,
+    "layer": "top",
+    "pcb_component_id": "pcb_component_simple_bug_0",
+    "port_hints": [
+      "5"
+    ],
+    "pcb_port_id": "pcb_port_4"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_7",
+    "shape": "rect",
+    "x": -6.4542506265664175,
+    "y": -1.7718070175438587,
+    "width": 1,
+    "height": 0.6,
+    "layer": "top",
+    "pcb_component_id": "pcb_component_simple_bug_0",
+    "port_hints": [
+      "6"
+    ],
+    "pcb_port_id": "pcb_port_5"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_8",
+    "shape": "rect",
+    "x": -6.4542506265664175,
+    "y": -3.041807017543859,
+    "width": 1,
+    "height": 0.6,
+    "layer": "top",
+    "pcb_component_id": "pcb_component_simple_bug_0",
+    "port_hints": [
+      "7"
+    ],
+    "pcb_port_id": "pcb_port_6"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_9",
+    "shape": "rect",
+    "x": -6.4542506265664175,
+    "y": -4.31180701754386,
+    "width": 1,
+    "height": 0.6,
+    "layer": "top",
+    "pcb_component_id": "pcb_component_simple_bug_0",
+    "port_hints": [
+      "8"
+    ],
+    "pcb_port_id": "pcb_port_7"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_10",
+    "shape": "rect",
+    "x": -3.554250626566417,
+    "y": -4.31180701754386,
+    "width": 1,
+    "height": 0.6,
+    "layer": "top",
+    "pcb_component_id": "pcb_component_simple_bug_0",
+    "port_hints": [
+      "9"
+    ]
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_11",
+    "shape": "rect",
+    "x": -3.554250626566417,
+    "y": -3.0418070175438596,
+    "width": 1,
+    "height": 0.6,
+    "layer": "top",
+    "pcb_component_id": "pcb_component_simple_bug_0",
+    "port_hints": [
+      "10"
+    ]
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_12",
+    "shape": "rect",
+    "x": -3.554250626566417,
+    "y": -1.7718070175438596,
+    "width": 1,
+    "height": 0.6,
+    "layer": "top",
+    "pcb_component_id": "pcb_component_simple_bug_0",
+    "port_hints": [
+      "11"
+    ]
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_13",
+    "shape": "rect",
+    "x": -3.554250626566417,
+    "y": -0.5018070175438596,
+    "width": 1,
+    "height": 0.6,
+    "layer": "top",
+    "pcb_component_id": "pcb_component_simple_bug_0",
+    "port_hints": [
+      "12"
+    ]
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_14",
+    "shape": "rect",
+    "x": -3.554250626566417,
+    "y": 0.7681929824561404,
+    "width": 1,
+    "height": 0.6,
+    "layer": "top",
+    "pcb_component_id": "pcb_component_simple_bug_0",
+    "port_hints": [
+      "13"
+    ]
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_15",
+    "shape": "rect",
+    "x": -3.554250626566417,
+    "y": 2.03819298245614,
+    "width": 1,
+    "height": 0.6,
+    "layer": "top",
+    "pcb_component_id": "pcb_component_simple_bug_0",
+    "port_hints": [
+      "14"
+    ]
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_16",
+    "shape": "rect",
+    "x": -3.554250626566417,
+    "y": 3.3081929824561405,
+    "width": 1,
+    "height": 0.6,
+    "layer": "top",
+    "pcb_component_id": "pcb_component_simple_bug_0",
+    "port_hints": [
+      "15"
+    ]
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_17",
+    "shape": "rect",
+    "x": -3.554250626566417,
+    "y": 4.578192982456141,
+    "width": 1,
+    "height": 0.6,
+    "layer": "top",
+    "pcb_component_id": "pcb_component_simple_bug_0",
+    "port_hints": [
+      "16"
+    ]
+  },
+  {
+    "type": "pcb_silkscreen_path",
+    "layer": "top",
+    "pcb_component_id": "pcb_component_simple_bug_0",
+    "pcb_silkscreen_path_id": "pcb_silkscreen_path_0",
+    "route": [
+      {
+        "x": -5.854250626566417,
+        "y": -4.6118070175438595
+      },
+      {
+        "x": -5.854250626566417,
+        "y": 4.878192982456141
+      },
+      {
+        "x": -5.2875839598997505,
+        "y": 4.878192982456141
+      },
+      {
+        "x": -5.266016494111282,
+        "y": 4.769766009952699
+      },
+      {
+        "x": -5.204597547902606,
+        "y": 4.677846061119952
+      },
+      {
+        "x": -5.112677599069859,
+        "y": 4.616427114911276
+      },
+      {
+        "x": -5.004250626566417,
+        "y": 4.5948596491228075
+      },
+      {
+        "x": -4.895823654062975,
+        "y": 4.616427114911276
+      },
+      {
+        "x": -4.803903705230229,
+        "y": 4.677846061119952
+      },
+      {
+        "x": -4.742484759021552,
+        "y": 4.769766009952699
+      },
+      {
+        "x": -4.720917293233084,
+        "y": 4.878192982456141
+      },
+      {
+        "x": -4.154250626566418,
+        "y": 4.878192982456141
+      },
+      {
+        "x": -4.154250626566418,
+        "y": -4.6118070175438595
+      },
+      {
+        "x": -5.854250626566417,
+        "y": -4.6118070175438595
+      }
+    ],
+    "stroke_width": 0.1
+  },
+  {
+    "type": "source_component",
+    "source_component_id": "simple_resistor_0",
+    "name": "R1",
+    "supplier_part_numbers": {},
+    "ftype": "simple_resistor",
+    "resistance": "10kohm"
+  },
+  {
+    "type": "schematic_component",
+    "source_component_id": "simple_resistor_0",
+    "schematic_component_id": "schematic_component_simple_resistor_0",
+    "rotation": 0,
+    "size": {
+      "width": 1,
+      "height": 0.3
+    },
+    "center": {
+      "x": -2.125,
+      "y": 0
+    }
+  },
+  {
+    "type": "source_port",
+    "name": "left",
+    "source_port_id": "source_port_8",
+    "source_component_id": "simple_resistor_0"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_8",
+    "source_port_id": "source_port_8",
+    "center": {
+      "x": -2.625,
+      "y": 0
+    },
+    "facing_direction": "left",
+    "schematic_component_id": "schematic_component_simple_resistor_0"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_8",
+    "source_port_id": "source_port_8",
+    "pcb_component_id": "pcb_component_simple_resistor_0",
+    "x": 1.8851077694235585,
+    "y": 0,
+    "layers": [
+      "top"
+    ]
+  },
+  {
+    "type": "source_port",
+    "name": "right",
+    "source_port_id": "source_port_9",
+    "source_component_id": "simple_resistor_0"
+  },
+  {
+    "type": "schematic_port",
+    "schematic_port_id": "schematic_port_9",
+    "source_port_id": "source_port_9",
+    "center": {
+      "x": -1.625,
+      "y": 0
+    },
+    "facing_direction": "right",
+    "schematic_component_id": "schematic_component_simple_resistor_0"
+  },
+  {
+    "type": "pcb_port",
+    "pcb_port_id": "pcb_port_9",
+    "source_port_id": "source_port_9",
+    "pcb_component_id": "pcb_component_simple_resistor_0",
+    "x": 3.7851077694235586,
+    "y": 0,
+    "layers": [
+      "top"
+    ]
+  },
+  {
+    "type": "schematic_text",
+    "text": "R1",
+    "schematic_text_id": "schematic_text_16",
+    "schematic_component_id": "schematic_component_simple_resistor_0",
+    "anchor": "left",
+    "position": {
+      "x": -2.325,
+      "y": -0.5
+    },
+    "rotation": 0
+  },
+  {
+    "type": "schematic_text",
+    "text": "10kohm",
+    "schematic_text_id": "schematic_text_17",
+    "schematic_component_id": "schematic_component_simple_resistor_0",
+    "anchor": "left",
+    "position": {
+      "x": -2.325,
+      "y": -0.3
+    },
+    "rotation": 0
+  },
+  {
+    "type": "pcb_component",
+    "source_component_id": "simple_resistor_0",
+    "pcb_component_id": "pcb_component_simple_resistor_0",
+    "layer": "top",
+    "center": {
+      "x": 2.8351077694235585,
+      "y": 0
+    },
+    "rotation": 0,
+    "width": 3.0999999999999996,
+    "height": 1.2
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_1",
+    "shape": "rect",
+    "x": 1.8851077694235585,
+    "y": 0,
+    "width": 1.2,
+    "height": 1.2,
+    "layer": "top",
+    "pcb_component_id": "pcb_component_simple_resistor_0",
+    "port_hints": [
+      "1",
+      "left"
+    ],
+    "pcb_port_id": "pcb_port_8"
+  },
+  {
+    "type": "pcb_smtpad",
+    "pcb_smtpad_id": "pcb_smtpad_3",
+    "shape": "rect",
+    "x": 3.7851077694235586,
+    "y": 0,
+    "width": 1.2,
+    "height": 1.2,
+    "layer": "top",
+    "pcb_component_id": "pcb_component_simple_resistor_0",
+    "port_hints": [
+      "2",
+      "right"
+    ],
+    "pcb_port_id": "pcb_port_9"
+  },
+  {
+    "pcb_error_id": "pcb_error_0",
+    "type": "pcb_error",
+    "message": "No elements found for selector: \".C1\"",
+    "error_type": "pcb_placement_error"
+  },
+  {
+    "pcb_error_id": "pcb_error_1",
+    "type": "pcb_error",
+    "message": "No elements found for selector: \".R2\"",
+    "error_type": "pcb_placement_error"
+  },
+  {
+    "type": "source_trace",
+    "source_trace_id": "source_trace_0",
+    "connected_source_port_ids": [
+      "source_port_0",
+      "source_port_8"
+    ],
+    "connected_source_net_ids": []
+  },
+  {
+    "type": "schematic_trace",
+    "source_trace_id": "source_trace_0",
+    "schematic_trace_id": "schematic_trace_0",
+    "edges": [
+      {
+        "from": {
+          "x": -0.8999999999999999,
+          "y": 0.8
+        },
+        "to": {
+          "x": -0.8999999999999999,
+          "y": 0.6000000000000001
+        }
+      },
+      {
+        "from": {
+          "x": -0.8999999999999999,
+          "y": 0.6000000000000001
+        },
+        "to": {
+          "x": -2.7,
+          "y": 0.6000000000000001
+        }
+      },
+      {
+        "from": {
+          "x": -2.7,
+          "y": 0.6000000000000001
+        },
+        "to": {
+          "x": -2.7,
+          "y": 0
+        }
+      },
+      {
+        "from": {
+          "x": -2.7,
+          "y": 0
+        },
+        "to": {
+          "x": -2.8000000000000003,
+          "y": 0
+        }
+      },
+      {
+        "from": {
+          "x": -0.75,
+          "y": 0.75,
+          "ti": 0
+        },
+        "to": {
+          "x": -0.8999999999999999,
+          "y": 0.8
+        }
+      },
+      {
+        "from": {
+          "x": -2.625,
+          "y": 0,
+          "ti": 1
+        },
+        "to": {
+          "x": -2.8000000000000003,
+          "y": 0
+        }
+      }
+    ]
+  },
+  {
+    "type": "pcb_trace",
+    "pcb_trace_id": "pcb_trace_0",
+    "source_trace_id": "source_trace_0",
+    "route": [
+      {
+        "route_type": "wire",
+        "layer": "top",
+        "width": 0.05,
+        "x": 1.9,
+        "y": 0
+      },
+      {
+        "route_type": "wire",
+        "layer": "top",
+        "width": 0.05,
+        "x": 1.4,
+        "y": 0
+      },
+      {
+        "route_type": "wire",
+        "layer": "top",
+        "width": 0.05,
+        "x": 1.4000000000000004,
+        "y": 0
+      },
+      {
+        "route_type": "wire",
+        "layer": "top",
+        "width": 0.05,
+        "x": 0.40000000000000036,
+        "y": 1
+      },
+      {
+        "route_type": "wire",
+        "layer": "top",
+        "width": 0.05,
+        "x": -0.40000000000000036,
+        "y": 1
+      },
+      {
+        "route_type": "wire",
+        "layer": "top",
+        "width": 0.05,
+        "x": -0.7999999999999998,
+        "y": 1.4000000000000004
+      },
+      {
+        "route_type": "wire",
+        "layer": "top",
+        "width": 0.05,
+        "x": -1.2000000000000002,
+        "y": 1.4000000000000004
+      },
+      {
+        "route_type": "wire",
+        "layer": "top",
+        "width": 0.05,
+        "x": -1.4000000000000004,
+        "y": 1.6
+      },
+      {
+        "route_type": "wire",
+        "layer": "top",
+        "width": 0.05,
+        "x": -2.2,
+        "y": 1.6
+      },
+      {
+        "route_type": "wire",
+        "layer": "top",
+        "width": 0.05,
+        "x": -3,
+        "y": 2.4000000000000004
+      },
+      {
+        "route_type": "wire",
+        "layer": "top",
+        "width": 0.05,
+        "x": -3.2,
+        "y": 2.4000000000000004
+      },
+      {
+        "route_type": "wire",
+        "layer": "top",
+        "width": 0.05,
+        "x": -3.5999999999999996,
+        "y": 2.8000000000000007
+      },
+      {
+        "route_type": "wire",
+        "layer": "top",
+        "width": 0.05,
+        "x": -4.4,
+        "y": 2.8000000000000007
+      },
+      {
+        "route_type": "wire",
+        "layer": "top",
+        "width": 0.05,
+        "x": -6,
+        "y": 4.4
+      },
+      {
+        "route_type": "wire",
+        "layer": "top",
+        "width": 0.05,
+        "x": -6.2,
+        "y": 4.4
+      },
+      {
+        "route_type": "wire",
+        "layer": "top",
+        "width": 0.05,
+        "x": -6.199999999999999,
+        "y": 4.4
+      },
+      {
+        "route_type": "wire",
+        "layer": "top",
+        "width": 0.05,
+        "x": -6.3,
+        "y": 4.5
+      },
+      {
+        "route_type": "wire",
+        "layer": "top",
+        "width": 0.05,
+        "x": -6.4,
+        "y": 4.5
+      },
+      {
+        "route_type": "wire",
+        "layer": "top",
+        "width": 0.05,
+        "x": -6.5,
+        "y": 4.6000000000000005
+      }
+    ]
+  },
+  {
+    "type": "pcb_board",
+    "center": {
+      "x": 0,
+      "y": 0
+    },
+    "width": 20,
+    "height": 20
+  }
+]


### PR DESCRIPTION
Closes - https://github.com/tscircuit/circuit-to-png/issues/12

- Adds the `schematic_port` and parse the text appropriately.
- Flips the schematic in Y-axis to match the schematic-viewer

<img width="653" alt="Screenshot 2024-08-11 at 2 20 50 AM" src="https://github.com/user-attachments/assets/37296df3-6da3-477e-bf09-3f50d4883334">
