### PR TITLE
feat: Integrate schematic symbols

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "circuit-to-svg",
-  "version": "0.0.3",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "circuit-to-svg",
-      "version": "0.0.3",
+      "version": "0.0.6",
       "license": "ISC",
       "dependencies": {
         "@tscircuit/routing": "^1.3.5",
+        "schematic-symbols": "^0.0.13",
         "svgson": "^5.3.1",
         "transformation-matrix": "^2.16.1"
       },
@@ -31,7 +32,7 @@
         "typescript": "^5.4.5"
       },
       "peerDependencies": {
-        "@tscircuit/soup": "^0.0.47"
+        "@tscircuit/soup": "^0.0.55"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -3890,9 +3891,9 @@
       }
     },
     "node_modules/@tscircuit/soup": {
-      "version": "0.0.47",
-      "resolved": "https://registry.npmjs.org/@tscircuit/soup/-/soup-0.0.47.tgz",
-      "integrity": "sha512-62Uac3KVTDBt/vZi3h6BBxKqZ1lsdPES+eoMvR0L7iLz76kRDjP6xVBaSrcvJLISJ1kQyp5GSyV5k9NN0yHBMA==",
+      "version": "0.0.55",
+      "resolved": "https://registry.npmjs.org/@tscircuit/soup/-/soup-0.0.55.tgz",
+      "integrity": "sha512-sxaTpfo+iLCUK3R2kMqF7RhakP9eCftogB6LW/BY0hrtvyClOTQ7tXoMKtQjdUpgube/JjLtMJISPsT+aj5/wA==",
       "peer": true,
       "dependencies": {
         "convert-units": "^2.3.4",
@@ -8629,6 +8630,14 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "node_modules/schematic-symbols": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/schematic-symbols/-/schematic-symbols-0.0.13.tgz",
+      "integrity": "sha512-skxjn3AeyJNk4EVbWSIldjXnbHBqHdQocRn8uW4XNeW9aKs/maCQY7zPC0mQKWvK0JRyNemPQgclJPYWLk3Uyw==",
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      }
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -9930,7 +9939,6 @@
     },
     "node_modules/typescript": {
       "version": "5.5.3",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -32,10 +32,11 @@
     "typescript": "^5.4.5"
   },
   "peerDependencies": {
-    "@tscircuit/soup": "^0.0.47"
+    "@tscircuit/soup": "^0.0.55"
   },
   "dependencies": {
     "@tscircuit/routing": "^1.3.5",
+    "schematic-symbols": "^0.0.13",
     "svgson": "^5.3.1",
     "transformation-matrix": "^2.16.1"
   }

--- a/src/lib/soup-to-svg.ts
+++ b/src/lib/soup-to-svg.ts
@@ -1,6 +1,6 @@
 import type { AnySoupElement } from "@tscircuit/soup";
 import { getSvg, symbols } from "schematic-symbols";
-import { parse, parseSync, stringify } from "svgson";
+import { parseSync, stringify } from "svgson";
 
 function circuitJsonToSchematicSvg(soup: AnySoupElement[]): string {
   let minX = Number.POSITIVE_INFINITY;

--- a/src/lib/soup-to-svg.ts
+++ b/src/lib/soup-to-svg.ts
@@ -1,8 +1,8 @@
 import type { AnySoupElement } from "@tscircuit/soup";
 import { getSvg, symbols } from "schematic-symbols";
-import { parse, stringify } from "svgson";
+import { parse, parseSync, stringify } from "svgson";
 
-async function circuitJsonToSchematicSvg(soup: AnySoupElement[]): Promise<string> {
+function circuitJsonToSchematicSvg(soup: AnySoupElement[]): string {
   let minX = Number.POSITIVE_INFINITY;
   let minY = Number.POSITIVE_INFINITY;
   let maxX = Number.NEGATIVE_INFINITY;
@@ -37,7 +37,7 @@ async function circuitJsonToSchematicSvg(soup: AnySoupElement[]): Promise<string
       x: component.center.x,
       y: flipY(component.center.y),
     };
-    const svg = await createSchematicComponent(
+    const svg = createSchematicComponent(
       flippedCenter,
       component.size,
       component.rotation || 0,
@@ -149,10 +149,10 @@ function createSchematicComponent(
 
   if(symbolName) {
     // TODO: Change the types in soup from string
-    return parse(getSvg((symbols as any)[symbolName], {
+    return parseSync(getSvg((symbols as any)[symbolName], {
       width: size.width,
       height: size.height,
-    })).then(json => json)
+    }))
   }
 
   return {

--- a/src/lib/soup-to-svg.ts
+++ b/src/lib/soup-to-svg.ts
@@ -1,7 +1,8 @@
 import type { AnySoupElement } from "@tscircuit/soup";
-import { stringify } from "svgson";
+import { getSvg, symbols } from "schematic-symbols";
+import { parse, stringify } from "svgson";
 
-function circuitJsonToSchematicSvg(soup: AnySoupElement[]): string {
+async function circuitJsonToSchematicSvg(soup: AnySoupElement[]): Promise<string> {
   let minX = Number.POSITIVE_INFINITY;
   let minY = Number.POSITIVE_INFINITY;
   let maxX = Number.NEGATIVE_INFINITY;
@@ -36,10 +37,11 @@ function circuitJsonToSchematicSvg(soup: AnySoupElement[]): string {
       x: component.center.x,
       y: flipY(component.center.y),
     };
-    const svg = createSchematicComponent(
+    const svg = await createSchematicComponent(
       flippedCenter,
       component.size,
-      component.rotation || 0
+      component.rotation || 0,
+      component.symbol_name
     );
     svgChildren.push(svg);
     componentMap.set(component.schematic_component_id, component);
@@ -140,9 +142,18 @@ function circuitJsonToSchematicSvg(soup: AnySoupElement[]): string {
 function createSchematicComponent(
   center: { x: number; y: number },
   size: { width: number; height: number },
-  rotation: number
+  rotation: number,
+  symbolName?: string
 ): any {
   const transform = `translate(${center.x}, ${center.y}) rotate(${(rotation * 180) / Math.PI})`;
+
+  if(symbolName) {
+    // TODO: Change the types in soup from string
+    return parse(getSvg((symbols as any)[symbolName], {
+      width: size.width,
+      height: size.height,
+    })).then(json => json)
+  }
 
   return {
     name: 'g',

--- a/src/stories/net-label-not-overlap.stories.tsx
+++ b/src/stories/net-label-not-overlap.stories.tsx
@@ -3,26 +3,9 @@ import { circuitJsonToSchematicSvg, circuitJsonToPcbSvg } from "../lib/index.js"
 import soup from "../utils/soup.json";
 
 export const NetLabelNotOverlap = () => {
-  const [svg, setSvg] = useState("");
+  const result = circuitJsonToSchematicSvg(soup);
 
-  useEffect(() => {
-    const fetchSvg = async () => {
-      try {
-        const result = await circuitJsonToSchematicSvg(soup);
-        setSvg(result);
-      } catch (error) {
-        console.error("Error generating SVG:", error);
-      }
-    };
-
-    fetchSvg();
-  }, []);
-
-  if (!svg) {
-    return <div>Loading...</div>;
-  }
-
-  return <div dangerouslySetInnerHTML={{ __html: svg }} />;
+  return <div dangerouslySetInnerHTML={{ __html: result }} />;
 };
 
 export default {

--- a/src/stories/net-label-not-overlap.stories.tsx
+++ b/src/stories/net-label-not-overlap.stories.tsx
@@ -1,18 +1,31 @@
-import React from "react";
-import { pcbSoupToSvg, soupToSvg } from "../lib/index.js";
+import React, { useEffect, useState } from "react";
+import { circuitJsonToSchematicSvg, circuitJsonToPcbSvg } from "../lib/index.js";
 import soup from "../utils/soup.json";
 
 export const NetLabelNotOverlap = () => {
-  const svg = pcbSoupToSvg(soup);
+  const [svg, setSvg] = useState("");
 
-  return (
-    <div
-      dangerouslySetInnerHTML={{ __html: svg }}
-    />
-  );
+  useEffect(() => {
+    const fetchSvg = async () => {
+      try {
+        const result = await circuitJsonToSchematicSvg(soup);
+        setSvg(result);
+      } catch (error) {
+        console.error("Error generating SVG:", error);
+      }
+    };
+
+    fetchSvg();
+  }, []);
+
+  if (!svg) {
+    return <div>Loading...</div>;
+  }
+
+  return <div dangerouslySetInnerHTML={{ __html: svg }} />;
 };
 
 export default {
-    title: 'Net Label Not Overlap',
-    component: NetLabelNotOverlap,
-}
+  title: "Net Label Not Overlap",
+  component: NetLabelNotOverlap,
+};


### PR DESCRIPTION
What do you think about this of using the `circuitJsonToSchematicSvg` as a Promise, cause the schematic-symbols is returned as a string and need to be `parse` by svgson?

Also, currently the [rotateSymbol](https://github.com/tscircuit/schematic-symbols/blob/43ef01b0161609f4ec792a95363368f99a5f405e/drawing/rotateSymbol.ts#L20) is not exported as well as not rotating the symbols by the value you pass. So, I think this needs to be an issue to work on.

