### PR TITLE
Add drawPaddingOutsideBoard option

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Converts a PCB layout description to an SVG string.
   resulting aspect ratio matches the `pcb_board` found in the circuit JSON.
 - `backgroundColor` – fill color for the SVG background rectangle. Defaults to
   `"#000"`.
+- `drawPaddingOutsideBoard` – if `false`, omit the board outline and extra
+  padding around it. Defaults to `true`.
 
 ## Contributing
 

--- a/tests/pcb/__snapshots__/draw-padding-outside-board-option.snap.svg
+++ b/tests/pcb/__snapshots__/draw-padding-outside-board-option.snap.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="600"><style></style><rect class="boundary" x="0" y="0" fill="#000" width="800" height="600"/></svg>

--- a/tests/pcb/__snapshots__/draw-padding-outside-board-option.snap.svg
+++ b/tests/pcb/__snapshots__/draw-padding-outside-board-option.snap.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="800" height="600"><style></style><rect class="boundary" x="0" y="0" fill="#000" width="800" height="600"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="600"><style></style><rect class="boundary" x="0" y="0" fill="#000" width="800" height="600"/><rect class="pcb-pad" fill="white" x="370" y="270" width="60" height="60"/><g><circle class="pcb-hole-outer" fill="rgb(200, 52, 52)" cx="520" cy="300" r="30"/><circle class="pcb-hole-inner" fill="rgb(255, 38, 226)" cx="520" cy="300" r="15"/></g></svg>

--- a/tests/pcb/draw-padding-outside-board-option.test.ts
+++ b/tests/pcb/draw-padding-outside-board-option.test.ts
@@ -1,0 +1,19 @@
+import { test, expect } from "bun:test"
+import { convertCircuitJsonToPcbSvg } from "lib"
+
+const circuit: any = [
+  {
+    type: "pcb_board",
+    pcb_board_id: "board0",
+    center: { x: 0, y: 0 },
+    width: 10,
+    height: 10,
+  },
+]
+
+test("drawPaddingOutsideBoard false", () => {
+  const svg = convertCircuitJsonToPcbSvg(circuit, {
+    drawPaddingOutsideBoard: false,
+  })
+  expect(svg).toMatchSvgSnapshot(import.meta.path)
+})

--- a/tests/pcb/draw-padding-outside-board-option.test.ts
+++ b/tests/pcb/draw-padding-outside-board-option.test.ts
@@ -9,11 +9,31 @@ const circuit: any = [
     width: 10,
     height: 10,
   },
+  {
+    type: "pcb_smtpad",
+    pcb_smtpad_id: "pad0",
+    shape: "rect",
+    width: 1,
+    height: 1,
+    x: 0,
+    y: 0,
+  },
+  {
+    type: "pcb_via",
+    pcb_via_id: "via0",
+    x: 2,
+    y: 0,
+    hole_diameter: 0.5,
+    outer_diameter: 1,
+    layers: ["top", "bottom"],
+    from_layer: "top",
+    to_layer: "bottom",
+  },
 ]
 
-test("drawPaddingOutsideBoard false", () => {
+test("drawPaddingOutsideBoard false", async () => {
   const svg = convertCircuitJsonToPcbSvg(circuit, {
     drawPaddingOutsideBoard: false,
   })
-  expect(svg).toMatchSvgSnapshot(import.meta.path)
-})
+  await expect(svg).toMatchSvgSnapshot(import.meta.path)
+}, 10000)


### PR DESCRIPTION
## Summary
- add `drawPaddingOutsideBoard` option to PCB SVG conversion
- skip board outline and margin when disabled
- document the new option
- test new behaviour

## Testing
- `npx tsc --noEmit`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_683f8eead4d4832e9a04639b3eafd269