### PR TITLE
Add debug box option for schematic symbols

### DIFF
--- a/lib/sch/convert-circuit-json-to-schematic-svg.ts
+++ b/lib/sch/convert-circuit-json-to-schematic-svg.ts
@@ -33,6 +33,7 @@ interface Options {
   height?: number
   grid?: boolean | { cellSize?: number; labelCells?: boolean }
   labeledPoints?: Array<{ x: number; y: number; label: string }>
+  drawSymbolDebugBoxes?: boolean
 }
 
 export function convertCircuitJsonToSchematicSvg(
@@ -139,6 +140,7 @@ export function convertCircuitJsonToSchematicSvg(
           transform,
           circuitJson,
           colorMap,
+          drawSymbolDebugBoxes: options?.drawSymbolDebugBoxes,
         }),
       )
     } else if (elm.type === "schematic_box") {
@@ -163,6 +165,7 @@ export function convertCircuitJsonToSchematicSvg(
           schNetLabel: elm,
           realToScreenTransform: transform,
           colorMap,
+          drawSymbolDebugBoxes: options?.drawSymbolDebugBoxes,
         }),
       )
     } else if (elm.type === "schematic_text" && !elm.schematic_component_id) {

--- a/lib/sch/svg-object-fns/create-svg-objects-for-sch-net-label-with-symbol.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-for-sch-net-label-with-symbol.ts
@@ -31,10 +31,12 @@ export const createSvgObjectsForSchNetLabelWithSymbol = ({
   schNetLabel,
   realToScreenTransform,
   colorMap,
+  drawSymbolDebugBoxes,
 }: {
   schNetLabel: SchematicNetLabel
   realToScreenTransform: Matrix
   colorMap: ColorMap
+  drawSymbolDebugBoxes?: boolean
 }): SvgObject[] => {
   if (!schNetLabel.text) return []
   const svgObjects: SvgObject[] = []
@@ -170,6 +172,25 @@ export const createSvgObjectsForSchNetLabelWithSymbol = ({
     },
     children: [],
   })
+  if (drawSymbolDebugBoxes) {
+    const strokeWidth = getSchStrokeSize(realToScreenTransform)
+    svgObjects.push({
+      name: "rect",
+      type: "element",
+      value: "",
+      attributes: {
+        x: rectX.toString(),
+        y: rectY.toString(),
+        width: rectWidth.toString(),
+        height: rectHeight.toString(),
+        fill: "rgba(255,0,0,0.2)",
+        stroke: "rgba(255,0,0,0.2)",
+        "stroke-width": `${strokeWidth}px`,
+        "stroke-dasharray": `${strokeWidth * 2},${strokeWidth * 2}`,
+      },
+      children: [],
+    })
+  }
 
   // Draw symbol paths
   for (const path of symbolPaths) {

--- a/lib/sch/svg-object-fns/create-svg-objects-for-sch-net-label.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-for-sch-net-label.ts
@@ -27,10 +27,12 @@ export const createSvgObjectsForSchNetLabel = ({
   schNetLabel,
   realToScreenTransform,
   colorMap,
+  drawSymbolDebugBoxes,
 }: {
   schNetLabel: SchematicNetLabel
   realToScreenTransform: Matrix
   colorMap: ColorMap
+  drawSymbolDebugBoxes?: boolean
 }): SvgObject[] => {
   if (!schNetLabel.text) return []
 
@@ -40,6 +42,7 @@ export const createSvgObjectsForSchNetLabel = ({
       schNetLabel,
       realToScreenTransform,
       colorMap,
+      drawSymbolDebugBoxes,
     })
   }
 

--- a/lib/sch/svg-object-fns/create-svg-objects-from-sch-component-with-box.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-from-sch-component-with-box.ts
@@ -21,11 +21,13 @@ export const createSvgObjectsFromSchematicComponentWithBox = ({
   transform,
   circuitJson,
   colorMap,
+  drawSymbolDebugBoxes,
 }: {
   component: SchematicComponent
   transform: Matrix
   circuitJson: AnyCircuitElement[]
   colorMap: ColorMap
+  drawSymbolDebugBoxes?: boolean
 }): SvgObject[] => {
   const svgObjects: SvgObject[] = []
 

--- a/lib/sch/svg-object-fns/create-svg-objects-from-sch-component-with-symbol.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-from-sch-component-with-symbol.ts
@@ -56,11 +56,13 @@ export const createSvgObjectsFromSchematicComponentWithSymbol = ({
   transform: realToScreenTransform,
   circuitJson,
   colorMap,
+  drawSymbolDebugBoxes,
 }: {
   component: SchematicComponent
   transform: Matrix
   circuitJson: AnyCircuitElement[]
   colorMap: ColorMap
+  drawSymbolDebugBoxes?: boolean
 }): SvgObject[] => {
   const svgObjects: SvgObject[] = []
 
@@ -145,6 +147,25 @@ export const createSvgObjectsFromSchematicComponentWithSymbol = ({
     },
     children: [],
   })
+  if (drawSymbolDebugBoxes) {
+    const strokeWidth = getSchStrokeSize(realToScreenTransform)
+    svgObjects.push({
+      name: "rect",
+      type: "element",
+      value: "",
+      attributes: {
+        x: rectX.toString(),
+        y: rectY.toString(),
+        width: rectWidth.toString(),
+        height: rectHeight.toString(),
+        fill: "rgba(255,0,0,0.2)",
+        stroke: "rgba(255,0,0,0.2)",
+        "stroke-width": `${strokeWidth}px`,
+        "stroke-dasharray": `${strokeWidth * 2},${strokeWidth * 2}`,
+      },
+      children: [],
+    })
+  }
   for (const path of paths) {
     const { points, color, closed, fill } = path
     svgObjects.push({

--- a/lib/sch/svg-object-fns/create-svg-objects-from-sch-component.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-from-sch-component.ts
@@ -10,6 +10,7 @@ export function createSvgObjectsFromSchematicComponent(params: {
   transform: Matrix
   circuitJson: AnyCircuitElement[]
   colorMap: ColorMap
+  drawSymbolDebugBoxes?: boolean
 }): SvgObject[] {
   const { component } = params
 


### PR DESCRIPTION
## Summary
- add `drawSymbolDebugBoxes` option to schematic conversion
- pass flag into component and net label renderers
- draw translucent dashed red rectangle around symbol bounds when enabled

## Testing
- `npx biome format lib/sch/svg-object-fns/create-svg-objects-from-sch-component-with-symbol.ts lib/sch/svg-object-fns/create-svg-objects-for-sch-net-label-with-symbol.ts lib/sch/svg-object-fns/create-svg-objects-for-sch-net-label.ts lib/sch/svg-object-fns/create-svg-objects-from-sch-component.ts lib/sch/svg-object-fns/create-svg-objects-from-sch-component-with-box.ts lib/sch/convert-circuit-json-to-schematic-svg.ts --write`
- `npx tsc --noEmit`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_683dea650474832e904aa13eb3059cb0