### PR TITLE
Update pcb SVG bounding

### DIFF
--- a/lib/pcb/convert-circuit-json-to-pcb-svg.ts
+++ b/lib/pcb/convert-circuit-json-to-pcb-svg.ts
@@ -168,8 +168,17 @@ export function convertCircuitJsonToPcbSvg(
   }
 
   const padding = drawPaddingOutsideBoard ? 1 : 0
-  const circuitWidth = maxX - minX + 2 * padding
-  const circuitHeight = maxY - minY + 2 * padding
+  const boundsMinX =
+    drawPaddingOutsideBoard || !isFinite(boardMinX) ? minX : boardMinX
+  const boundsMinY =
+    drawPaddingOutsideBoard || !isFinite(boardMinY) ? minY : boardMinY
+  const boundsMaxX =
+    drawPaddingOutsideBoard || !isFinite(boardMaxX) ? maxX : boardMaxX
+  const boundsMaxY =
+    drawPaddingOutsideBoard || !isFinite(boardMaxY) ? maxY : boardMaxY
+
+  const circuitWidth = boundsMaxX - boundsMinX + 2 * padding
+  const circuitHeight = boundsMaxY - boundsMinY + 2 * padding
 
   let svgWidth = options?.width ?? 800
   let svgHeight = options?.height ?? 600
@@ -206,8 +215,8 @@ export function convertCircuitJsonToPcbSvg(
 
   const transform = compose(
     translate(
-      offsetX - minX * scaleFactor + padding * scaleFactor,
-      svgHeight - offsetY + minY * scaleFactor - padding * scaleFactor,
+      offsetX - boundsMinX * scaleFactor + padding * scaleFactor,
+      svgHeight - offsetY + boundsMinY * scaleFactor - padding * scaleFactor,
     ),
     scale(scaleFactor, -scaleFactor), // Flip in y-direction
   )

--- a/tests/pcb/__snapshots__/offboard-element.snap.svg
+++ b/tests/pcb/__snapshots__/offboard-element.snap.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="600"><style></style><rect class="boundary" x="0" y="0" fill="#000" width="800" height="600"/><rect class="pcb-pad" fill="white" x="790" y="270" width="60" height="60"/></svg>

--- a/tests/pcb/offboard-element.test.ts
+++ b/tests/pcb/offboard-element.test.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "bun:test"
+import { convertCircuitJsonToPcbSvg } from "lib"
+
+const circuit: any = [
+  {
+    type: "pcb_board",
+    pcb_board_id: "board0",
+    center: { x: 0, y: 0 },
+    width: 10,
+    height: 10,
+  },
+  {
+    type: "pcb_smtpad",
+    pcb_smtpad_id: "pad-offboard",
+    shape: "rect",
+    width: 1,
+    height: 1,
+    x: 7,
+    y: 0,
+  },
+]
+
+test("offboard element does not affect bounds", async () => {
+  const svg = convertCircuitJsonToPcbSvg(circuit, {
+    drawPaddingOutsideBoard: false,
+  })
+  await expect(svg).toMatchSvgSnapshot(import.meta.path)
+}, 10000)


### PR DESCRIPTION
## Summary
- refine svg bounds when `drawPaddingOutsideBoard` is `false`
- keep transform calculations relative to board bounds

## Testing
- `npm run format`
- `npm run format:check`
- `npx tsc --noEmit`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_684094e90054832e9fc10205e6d8b571