### PR TITLE
Fix junction color inversion on trace hover

### DIFF
--- a/lib/sch/convert-circuit-json-to-schematic-svg.ts
+++ b/lib/sch/convert-circuit-json-to-schematic-svg.ts
@@ -238,6 +238,9 @@ export function convertCircuitJsonToSchematicSvg(
               .trace:hover .trace-crossing-outline {
                 opacity: 0;
               }
+              .trace:hover .trace-junction {
+                filter: invert(1);
+              }
               .text { font-family: sans-serif; fill: ${colorMap.schematic.wire}; }
               .pin-number { fill: ${colorMap.schematic.pin_number}; }
               .port-label { fill: ${colorMap.schematic.reference}; }

--- a/lib/sch/svg-object-fns/create-svg-objects-from-sch-trace.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-from-sch-trace.ts
@@ -152,6 +152,7 @@ export function createSchematicTrace({
           cx: screenX.toString(),
           cy: screenY.toString(),
           r: (Math.abs(transform.a) * 0.03).toString(),
+          class: "trace-junction",
           fill: colorMap.schematic.junction,
         },
         value: "",


### PR DESCRIPTION
## Summary
- add `.trace-junction` class for junction circles
- invert junction circles on trace hover

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_68448c8c768c832794133c32a5bffcbc


/close #253 