### PR TITLE
Implement inverted pin label overline

### DIFF
--- a/lib/sch/svg-object-fns/create-svg-objects-for-sch-net-label-with-symbol.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-for-sch-net-label-with-symbol.ts
@@ -37,6 +37,8 @@ export const createSvgObjectsForSchNetLabelWithSymbol = ({
   colorMap: ColorMap
 }): SvgObject[] => {
   if (!schNetLabel.text) return []
+  const isNegated = schNetLabel.text.startsWith("N_")
+  const labelText = isNegated ? schNetLabel.text.slice(2) : schNetLabel.text
   const svgObjects: SvgObject[] = []
 
   // If symbol name is provided, draw the symbol
@@ -66,12 +68,12 @@ export const createSvgObjectsForSchNetLabelWithSymbol = ({
 
   // Use the same positioning logic as the net label text
   const fontSizeMm = getSchMmFontSize("net_label")
-  const textWidthFSR = estimateTextWidth(schNetLabel.text || "")
+  const textWidthFSR = estimateTextWidth(labelText || "")
 
   const fullWidthFsr =
     textWidthFSR +
     ARROW_POINT_WIDTH_FSR * 2 +
-    END_PADDING_EXTRA_PER_CHARACTER_FSR * schNetLabel.text.length +
+    END_PADDING_EXTRA_PER_CHARACTER_FSR * labelText.length +
     END_PADDING_FSR
 
   const realTextGrowthVec = getUnitVectorFromOutsideToEdge(
@@ -208,7 +210,7 @@ export const createSvgObjectsForSchNetLabelWithSymbol = ({
 
     let textValue = text.text
     if (textValue === "{REF}") {
-      textValue = schNetLabel.text || ""
+      textValue = labelText || ""
     } else if (textValue === "{VAL}") {
       textValue = "" // You can modify this if needed
     }
@@ -237,6 +239,9 @@ export const createSvgObjectsForSchNetLabelWithSymbol = ({
         "text-anchor": ninePointAnchorToTextAnchor[text.anchor],
         "dominant-baseline": ninePointAnchorToDominantBaseline[text.anchor],
         "font-size": `${getSchScreenFontSize(realToScreenTransform, "reference_designator")}px`,
+        ...(isNegated && textValue === labelText
+          ? { style: "text-decoration: overline;" }
+          : {}),
       },
       children: [
         {

--- a/lib/sch/svg-object-fns/create-svg-objects-for-sch-net-label.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-for-sch-net-label.ts
@@ -34,6 +34,9 @@ export const createSvgObjectsForSchNetLabel = ({
 }): SvgObject[] => {
   if (!schNetLabel.text) return []
 
+  const isNegated = schNetLabel.text.startsWith("N_")
+  const labelText = isNegated ? schNetLabel.text.slice(2) : schNetLabel.text
+
   // If symbol_name is provided, use the symbol renderer
   if (schNetLabel.symbol_name) {
     return createSvgObjectsForSchNetLabelWithSymbol({
@@ -47,7 +50,7 @@ export const createSvgObjectsForSchNetLabel = ({
 
   const fontSizePx = getSchScreenFontSize(realToScreenTransform, "net_label")
   const fontSizeMm = getSchMmFontSize("net_label")
-  const textWidthFSR = estimateTextWidth(schNetLabel.text || "")
+  const textWidthFSR = estimateTextWidth(labelText || "")
 
   // Transform the center position to screen coordinates
   const screenCenter = applyToPoint(realToScreenTransform, schNetLabel.center)
@@ -62,7 +65,7 @@ export const createSvgObjectsForSchNetLabel = ({
   const fullWidthFsr =
     textWidthFSR +
     ARROW_POINT_WIDTH_FSR * 2 +
-    END_PADDING_EXTRA_PER_CHARACTER_FSR * schNetLabel.text.length +
+    END_PADDING_EXTRA_PER_CHARACTER_FSR * labelText.length +
     END_PADDING_FSR
   const screenAnchorPosition = schNetLabel.anchor_position
     ? applyToPoint(realToScreenTransform, schNetLabel.anchor_position)
@@ -108,7 +111,7 @@ export const createSvgObjectsForSchNetLabel = ({
       x:
         ARROW_POINT_WIDTH_FSR * 2 +
         END_PADDING_FSR +
-        END_PADDING_EXTRA_PER_CHARACTER_FSR * schNetLabel.text.length +
+        END_PADDING_EXTRA_PER_CHARACTER_FSR * labelText.length +
         textWidthFSR,
       y: 0.6,
     },
@@ -117,7 +120,7 @@ export const createSvgObjectsForSchNetLabel = ({
       x:
         ARROW_POINT_WIDTH_FSR * 2 +
         END_PADDING_FSR +
-        END_PADDING_EXTRA_PER_CHARACTER_FSR * schNetLabel.text.length +
+        END_PADDING_EXTRA_PER_CHARACTER_FSR * labelText.length +
         textWidthFSR,
       y: -0.6,
     },
@@ -197,11 +200,12 @@ export const createSvgObjectsForSchNetLabel = ({
       "font-variant-numeric": "tabular-nums",
       "font-size": `${fontSizePx}px`,
       transform: textTransformString,
+      ...(isNegated ? { style: "text-decoration: overline;" } : {}),
     },
     children: [
       {
         type: "text",
-        value: schNetLabel.text || "",
+        value: labelText || "",
         name: "",
         attributes: {},
         children: [],

--- a/lib/sch/svg-object-fns/create-svg-objects-for-sch-port-pin-label.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-for-sch-port-pin-label.ts
@@ -46,6 +46,9 @@ export const createSvgObjectsForSchPortPinLabel = (params: {
 
   if (!label) return []
 
+  const isNegated = label.startsWith("N_")
+  const displayLabel = isNegated ? label.slice(2) : label
+
   svgObjects.push({
     name: "text",
     type: "element",
@@ -53,7 +56,7 @@ export const createSvgObjectsForSchPortPinLabel = (params: {
       class: "pin-number",
       x: screenPinNumberTextPos.x.toString(),
       y: screenPinNumberTextPos.y.toString(),
-      style: "font-family: sans-serif;",
+      style: `font-family: sans-serif;${isNegated ? " text-decoration: overline;" : ""}`,
       fill: colorMap.schematic.pin_number,
       "text-anchor":
         schPort.side_of_component === "left" ||
@@ -71,7 +74,7 @@ export const createSvgObjectsForSchPortPinLabel = (params: {
     children: [
       {
         type: "text",
-        value: label || "",
+        value: displayLabel || "",
         name: "",
         attributes: {},
         children: [],

--- a/tests/sch/__snapshots__/inverted-pin-label.snap.svg
+++ b/tests/sch/__snapshots__/inverted-pin-label.snap.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="600" style="background-color: rgb(245, 241, 237)" data-real-to-screen-transform="matrix(326.0869565217,0,0,-326.0869565217,600,300)" data-software-used-string="@tscircuit/core@0.0.477"><style>
+              .boundary { fill: rgb(245, 241, 237); }
+              .schematic-boundary { fill: none; stroke: #fff; }
+              .component { fill: none; stroke: rgb(132, 0, 0); }
+              .chip { fill: rgb(255, 255, 194); stroke: rgb(132, 0, 0); }
+              .component-pin { fill: none; stroke: rgb(132, 0, 0); }
+              .trace:hover {
+                filter: invert(1);
+              }
+              .trace:hover .trace-crossing-outline {
+                opacity: 0;
+              }
+              .trace:hover .trace-junction {
+                filter: invert(1);
+              }
+              .text { font-family: sans-serif; fill: rgb(0, 150, 0); }
+              .pin-number { fill: rgb(169, 0, 0); }
+              .port-label { fill: rgb(0, 100, 100); }
+              .component-name { fill: rgb(0, 100, 100); }
+            </style><rect class="boundary" x="0" y="0" width="1200" height="600"/><g data-circuit-json-type="schematic_component" data-schematic-component-id="schematic_component_0"><rect class="component chip" x="355.43478260872496" y="234.78260869565997" width="489.1304347825501" height="130.43478260868005" stroke-width="6.521739130434001px" fill="rgb(255, 255, 194)" stroke="rgb(132, 0, 0)"/><rect class="component-overlay" x="355.43478260872496" y="234.78260869565997" width="489.1304347825501" height="130.43478260868005" fill="transparent"/><text x="355.43478260872496" y="407.60869565216103" fill="#006464" text-anchor="start" dominant-baseline="middle" font-family="sans-serif" font-size="58.695652173906px" transform="rotate(0, 355.43478260872496, 407.60869565216103)"></text><text x="355.43478260872496" y="192.39130434783897" fill="#006464" text-anchor="start" dominant-baseline="middle" font-family="sans-serif" font-size="58.695652173906px" transform="rotate(0, 355.43478260872496, 192.39130434783897)">U1</text><line class="component-pin" x1="231.52173913047903" y1="300" x2="355.434782608725" y2="300" stroke-width="6.521739130434001px"/><circle class="component-pin" cx="225.00000000004502" cy="300" r="6.521739130434001" stroke-width="6.521739130434001px"/><text class="pin-number" x="290.217391304385" y="293.478260869566" style="font-family: sans-serif;" fill="rgb(169, 0, 0)" text-anchor="middle" dominant-baseline="auto" font-size="48.913043478255px" transform="">1</text><text class="pin-number" x="388.04347826089503" y="300" style="font-family: sans-serif; text-decoration: overline;" fill="rgb(169, 0, 0)" text-anchor="start" dominant-baseline="middle" font-size="48.913043478255px" transform="">CS</text><line class="component-pin" x1="968.4782608695209" y1="300" x2="844.5652173912749" y2="300" stroke-width="6.521739130434001px"/><circle class="component-pin" cx="974.999999999955" cy="300" r="6.521739130434001" stroke-width="6.521739130434001px"/><text class="pin-number" x="909.782608695615" y="293.478260869566" style="font-family: sans-serif;" fill="rgb(169, 0, 0)" text-anchor="middle" dominant-baseline="auto" font-size="48.913043478255px" transform="">8</text><text class="pin-number" x="811.956521739105" y="300" style="font-family: sans-serif;" fill="rgb(169, 0, 0)" text-anchor="end" dominant-baseline="middle" font-size="48.913043478255px" transform="">VCC</text></g></svg>

--- a/tests/sch/inverted-pin-label.test.tsx
+++ b/tests/sch/inverted-pin-label.test.tsx
@@ -1,0 +1,35 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToSchematicSvg } from "lib/index"
+import { getTestFixture } from "tests/fixtures/get-test-fixture"
+
+// Test that N_ prefix is rendered with overline
+
+test("schematic inverted pin label", async () => {
+  const { circuit } = getTestFixture()
+
+  circuit.add(
+    <board width="10mm" height="10mm">
+      <chip
+        name="U1"
+        footprint="soic8"
+        pinLabels={{
+          pin1: "N_CS",
+          pin8: "VCC",
+        }}
+        schPortArrangement={{
+          leftSide: { pins: [1], direction: "top-to-bottom" },
+          rightSide: { pins: [8], direction: "top-to-bottom" },
+        }}
+      />
+    </board>,
+  )
+
+  await circuit.renderUntilSettled()
+
+  const svg = convertCircuitJsonToSchematicSvg(
+    circuit.getCircuitJson() as AnyCircuitElement[],
+  )
+
+  expect(svg).toMatchSvgSnapshot(import.meta.path)
+})


### PR DESCRIPTION
## Summary
- add overline styling for pin labels and net labels that start with `N_`
- compute net label widths based on trimmed label text
- test inverted pin label rendering

## Testing
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/sch/inverted-pin-label.test.tsx`
- `bun test tests/sch/net-label.test.tsx`
- `bun test tests/sch/chip-crossing-schemtic-example1.test.tsx`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_685ad3ee0ab0832e8c02eca3c6d68e06