### PR TITLE
Add hover rect for connected ports

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,7 +27,7 @@
         "@tscircuit/plop": "^0.0.10",
         "@types/bun": "^1.2.8",
         "biome": "^0.3.3",
-        "bun-match-svg": "^0.0.6",
+        "bun-match-svg": "^0.0.12",
         "circuit-json": "^0.0.218",
         "esbuild": "^0.20.2",
         "performance-now": "^2.1.0",
@@ -415,7 +415,7 @@
 
     "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
-    "bun-match-svg": ["bun-match-svg@0.0.6", "", { "dependencies": { "looks-same": "^9.0.1" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-Cr2zEZ2eaUoLh5P8NEcoseKGx/Yl8tgkDERboiTXspjCXJTM9R06CutNV1GkxJ+HZ6bW/1MZ0CqG/LASVorVPA=="],
+    "bun-match-svg": ["bun-match-svg@0.0.12", "", { "dependencies": { "looks-same": "^9.0.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "bin": { "bun-match-svg": "cli.ts" } }, "sha512-qjQtTwRvuqGDe8xza1OEm3OMA4bUEuFDl4i4y1vH9GwdEegqB9x1/H5+AjoRwQUcMmt5kP9bfPdplkBWxmlfWg=="],
 
     "bun-types": ["bun-types@1.2.15", "", { "dependencies": { "@types/node": "*" } }, "sha512-NarRIaS+iOaQU1JPfyKhZm4AsUOrwUOqRNHY0XxI8GI8jYxiLXLcdjYMG9UKS+fwWasc1uw1htV9AX24dD+p4w=="],
 

--- a/lib/sch/svg-object-fns/create-svg-objects-for-sch-port-box-line.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-for-sch-port-box-line.ts
@@ -93,23 +93,49 @@ export const createSvgObjectsForSchPortBoxLine = ({
   })
 
   const isConnected = isSourcePortConnected(circuitJson, schPort.source_port_id)
+  const pinRadiusPx = Math.abs(transform.a) * PIN_CIRCLE_RADIUS_MM
+
+  const pinChildren: SvgObject[] = []
 
   if (!isConnected) {
-    // Add port circle if the port is not connected
-    svgObjects.push({
+    pinChildren.push({
       name: "circle",
       type: "element",
       attributes: {
         class: "component-pin",
         cx: screenSchPortPos.x.toString(),
         cy: screenSchPortPos.y.toString(),
-        r: (Math.abs(transform.a) * PIN_CIRCLE_RADIUS_MM).toString(),
+        r: pinRadiusPx.toString(),
         "stroke-width": `${getSchStrokeSize(transform)}px`,
       },
       value: "",
       children: [],
     })
   }
+
+  pinChildren.push({
+    name: "rect",
+    type: "element",
+    attributes: {
+      x: (screenSchPortPos.x - pinRadiusPx).toString(),
+      y: (screenSchPortPos.y - pinRadiusPx).toString(),
+      width: (pinRadiusPx * 2).toString(),
+      height: (pinRadiusPx * 2).toString(),
+      opacity: "0",
+    },
+    value: "",
+    children: [],
+  })
+
+  svgObjects.push({
+    name: "g",
+    type: "element",
+    value: "",
+    attributes: {
+      "data-schematic-port-id": schPort.source_port_id,
+    },
+    children: pinChildren,
+  })
 
   return svgObjects
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@tscircuit/plop": "^0.0.10",
     "@types/bun": "^1.2.8",
     "biome": "^0.3.3",
-    "bun-match-svg": "^0.0.6",
+    "bun-match-svg": "^0.0.12",
     "circuit-json": "^0.0.218",
     "esbuild": "^0.20.2",
     "performance-now": "^2.1.0",


### PR DESCRIPTION
## Summary
- update `bun-match-svg` dependency
- handle pin hover by adding invisible rect for ports
- include data attribute for schematic port ids

## Testing
- `npx tsc --noEmit`
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/sch`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_6871a24e0eb0832ea4d65c1dc1dd380f