### PR TITLE
Support not connected port symbol

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -32,7 +32,7 @@
         "esbuild": "^0.20.2",
         "performance-now": "^2.1.0",
         "react": "^18.3.1",
-        "schematic-symbols": "^0.0.153",
+        "schematic-symbols": "^0.0.169",
         "storybook": "^8.2.5",
         "tsup": "^8.0.2",
         "typescript": "^5.4.5",
@@ -42,7 +42,7 @@
         "@tscircuit/circuit-json-util": "*",
         "@tscircuit/footprinter": "*",
         "circuit-json": "*",
-        "schematic-symbols": "*",
+        "schematic-symbols": "^0.0.169",
       },
     },
   },
@@ -973,7 +973,7 @@
 
     "scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
 
-    "schematic-symbols": ["schematic-symbols@0.0.153", "", { "peerDependencies": { "typescript": "^5.5.4" } }, "sha512-xinMH1jTXCyYK6W0O4A/18tyREzfFMIvLgWVorneal47XryqBRtXVgH+TsG7icnD5xGBuo81yNei+i8VMZqMoQ=="],
+    "schematic-symbols": ["schematic-symbols@0.0.169", "", { "peerDependencies": { "typescript": "^5.5.4" } }, "sha512-BlqQZ8HGGkIdGaI31bsXCTuVTlK/Ct2XwMy+nMORAXzT3DYfVP07kmaka7HwIpqi2KWTdYhIsGTEr16HW4nT/A=="],
 
     "semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 

--- a/lib/sch/svg-object-fns/create-svg-objects-for-not-connected-symbol.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-for-not-connected-symbol.ts
@@ -1,0 +1,83 @@
+import type { SchematicPort } from "circuit-json"
+import type { SvgObject } from "lib/svg-object"
+import type { ColorMap } from "lib/utils/colors"
+import { symbols } from "schematic-symbols"
+import {
+  applyToPoint,
+  compose,
+  translate,
+  type Matrix,
+} from "transformation-matrix"
+import { getSchStrokeSize } from "lib/utils/get-sch-stroke-size"
+
+export const createSvgObjectsForNotConnectedSymbol = ({
+  schPort,
+  transform,
+  colorMap,
+}: {
+  schPort: SchematicPort
+  transform: Matrix
+  colorMap: ColorMap
+}): SvgObject[] => {
+  if (schPort.is_connected !== false) return []
+
+  const direction =
+    schPort.facing_direction ?? schPort.side_of_component ?? "right"
+  const symbolName = `not_connected_${direction}` as keyof typeof symbols
+  const symbol = symbols[symbolName]
+  if (!symbol) return []
+
+  const port = symbol.ports[0]
+  const symbolToReal = translate(
+    schPort.center.x - port.x,
+    schPort.center.y - port.y,
+  )
+
+  const svgObjects: SvgObject[] = []
+  const paths = symbol.primitives.filter((p) => p.type === "path")
+  const circles = symbol.primitives.filter((p) => p.type === "circle")
+
+  for (const path of paths) {
+    const d =
+      path.points
+        .map((p, i) => {
+          const { x, y } = applyToPoint(compose(transform, symbolToReal), p)
+          return `${i === 0 ? "M" : "L"} ${x} ${y}`
+        })
+        .join(" ") + (path.closed ? " Z" : "")
+    svgObjects.push({
+      name: "path",
+      type: "element",
+      attributes: {
+        d,
+        stroke: colorMap.schematic.component_outline,
+        fill: path.fill ? colorMap.schematic.component_outline : "none",
+        "stroke-width": `${getSchStrokeSize(transform)}px`,
+        "stroke-linecap": "round",
+      },
+      value: "",
+      children: [],
+    })
+  }
+
+  for (const circle of circles) {
+    const { x, y } = applyToPoint(compose(transform, symbolToReal), circle)
+    const r = Math.abs(circle.radius * transform.a)
+    svgObjects.push({
+      name: "circle",
+      type: "element",
+      attributes: {
+        cx: x.toString(),
+        cy: y.toString(),
+        r: r.toString(),
+        fill: circle.fill ? colorMap.schematic.component_outline : "none",
+        stroke: colorMap.schematic.component_outline,
+        "stroke-width": `${getSchStrokeSize(transform)}px`,
+      },
+      value: "",
+      children: [],
+    })
+  }
+
+  return svgObjects
+}

--- a/lib/sch/svg-object-fns/create-svg-objects-for-sch-port-box-line.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-for-sch-port-box-line.ts
@@ -92,12 +92,15 @@ export const createSvgObjectsForSchPortBoxLine = ({
     children: [],
   })
 
-  const isConnected = isSourcePortConnected(circuitJson, schPort.source_port_id)
+  const isConnected =
+    schPort.is_connected === false
+      ? false
+      : isSourcePortConnected(circuitJson, schPort.source_port_id)
   const pinRadiusPx = Math.abs(transform.a) * PIN_CIRCLE_RADIUS_MM
 
   const pinChildren: SvgObject[] = []
 
-  if (!isConnected) {
+  if (!isConnected && schPort.is_connected !== false) {
     pinChildren.push({
       name: "circle",
       type: "element",

--- a/lib/sch/svg-object-fns/create-svg-objects-from-sch-component-with-box.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-from-sch-component-with-box.ts
@@ -102,6 +102,7 @@ export const createSvgObjectsFromSchematicComponentWithBox = ({
         schComponent,
         transform,
         circuitJson,
+        colorMap,
       }),
     )
   }

--- a/lib/sch/svg-object-fns/create-svg-objects-from-sch-component-with-symbol.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-from-sch-component-with-symbol.ts
@@ -21,6 +21,7 @@ import { getSchScreenFontSize } from "lib/utils/get-sch-font-size"
 import type { TextPrimitive } from "schematic-symbols"
 import { createSvgSchErrorText } from "./create-svg-error-text"
 import { isSourcePortConnected } from "lib/utils/is-source-port-connected"
+import { createSvgObjectsForNotConnectedSymbol } from "./create-svg-objects-for-not-connected-symbol"
 
 const ninePointAnchorToTextAnchor: Record<
   TextPrimitive["anchor"],
@@ -263,9 +264,20 @@ export const createSvgObjectsFromSchematicComponentWithSymbol = ({
     })
   }
 
-  // Draw Ports for debugging
+  // Draw Ports for debugging and not connected symbols
   for (const port of symbol.ports) {
     if (connectedSymbolPorts.has(port)) continue
+    const match = schPortsWithSymbolPorts.find((m) => m.symbolPort === port)
+    if (match && match.schPort.is_connected === false) {
+      svgObjects.push(
+        ...createSvgObjectsForNotConnectedSymbol({
+          schPort: match.schPort,
+          transform: realToScreenTransform,
+          colorMap,
+        }),
+      )
+      continue
+    }
     const screenPortPos = applyToPoint(
       compose(realToScreenTransform, transformFromSymbolToReal),
       port,

--- a/lib/sch/svg-object-fns/create-svg-objects-from-sch-port-on-box.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-from-sch-port-on-box.ts
@@ -9,19 +9,29 @@ import { su } from "@tscircuit/circuit-json-util"
 import { createSvgObjectsForSchPortBoxLine } from "./create-svg-objects-for-sch-port-box-line"
 import { createSvgObjectsForSchPortPinNumberText } from "./create-svg-objects-for-sch-port-pin-number-text"
 import { createSvgObjectsForSchPortPinLabel } from "./create-svg-objects-for-sch-port-pin-label"
+import type { ColorMap } from "lib/utils/colors"
+import { createSvgObjectsForNotConnectedSymbol } from "./create-svg-objects-for-not-connected-symbol"
 
 export const createSvgObjectsFromSchPortOnBox = (params: {
   schPort: SchematicPort
   schComponent: SchematicComponent
   transform: Matrix
   circuitJson: AnyCircuitElement[]
+  colorMap: ColorMap
 }): SvgObject[] => {
   const svgObjects: SvgObject[] = []
-  const { schPort, schComponent, transform, circuitJson } = params
+  const { schPort, schComponent, transform, circuitJson, colorMap } = params
 
   svgObjects.push(...createSvgObjectsForSchPortBoxLine(params))
   svgObjects.push(...createSvgObjectsForSchPortPinNumberText(params))
   svgObjects.push(...createSvgObjectsForSchPortPinLabel(params))
+  svgObjects.push(
+    ...createSvgObjectsForNotConnectedSymbol({
+      schPort,
+      transform,
+      colorMap,
+    }),
+  )
 
   return svgObjects
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "esbuild": "^0.20.2",
     "performance-now": "^2.1.0",
     "react": "^18.3.1",
-    "schematic-symbols": "^0.0.153",
+    "schematic-symbols": "^0.0.169",
     "storybook": "^8.2.5",
     "tsup": "^8.0.2",
     "typescript": "^5.4.5",

--- a/tests/sch/__snapshots__/not-connected-port.snap.svg
+++ b/tests/sch/__snapshots__/not-connected-port.snap.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="600" style="background-color: rgb(245, 241, 237)" data-real-to-screen-transform="matrix(428.5714285714,0,0,-428.5714285714,600,300)"><style>
+              .boundary { fill: rgb(245, 241, 237); }
+              .schematic-boundary { fill: none; stroke: #fff; }
+              .component { fill: none; stroke: rgb(132, 0, 0); }
+              .chip { fill: rgb(255, 255, 194); stroke: rgb(132, 0, 0); }
+              .component-pin { fill: none; stroke: rgb(132, 0, 0); }
+              .trace:hover {
+                filter: invert(1);
+              }
+              .trace:hover .trace-crossing-outline {
+                opacity: 0;
+              }
+              .trace:hover .trace-junction {
+                filter: invert(1);
+              }
+              .text { font-family: sans-serif; fill: rgb(0, 150, 0); }
+              .pin-number { fill: rgb(169, 0, 0); }
+              .port-label { fill: rgb(0, 100, 100); }
+              .component-name { fill: rgb(0, 100, 100); }
+            </style><rect class="boundary" x="0" y="0" width="1200" height="600"/><g data-circuit-json-type="schematic_component" data-schematic-component-id="sc1"><rect class="component-overlay" x="332.8780206530554" y="236.3935272448732" width="493.64666435007837" height="123.41170107035492" fill="transparent"/><path d="M 332.8780206530554 298.0993777800507 L 456.2896750796296 298.0993777800507" stroke="rgb(132, 0, 0)" fill="none" stroke-width="8.571428571428001px" stroke-linecap="round"/><path d="M 703.1129839327789 298.0993777800507 L 826.5246850031338 298.0993777800507" stroke="rgb(132, 0, 0)" fill="none" stroke-width="8.571428571428001px" stroke-linecap="round"/><path d="M 579.7012828624233 236.3935272448732 L 703.1129372889975 236.3935272448732 L 703.1129372889975 359.80522831522813 L 456.28958179206757 359.80522831522813 L 456.28958179206757 236.3935272448732 L 579.7012828624225 236.3935272448732" stroke="rgb(132, 0, 0)" fill="none" stroke-width="8.571428571428001px" stroke-linecap="round"/><text x="571.6245857142877" y="212.6329456267303" fill="rgb(15, 15, 15)" font-family="sans-serif" text-anchor="middle" dominant-baseline="auto" font-size="77.142857142852px">R1</text><text x="571.6245857142877" y="393.97800782883223" fill="rgb(15, 15, 15)" font-family="sans-serif" text-anchor="middle" dominant-baseline="hanging" font-size="77.142857142852px">1kΩ</text><path d="M 300.00000000001995 257.14285714286 L 214.28571428573997 342.85714285714" stroke="rgb(132, 0, 0)" fill="none" stroke-width="8.571428571428001px" stroke-linecap="round"/><path d="M 300.00000000001995 342.85714285714 L 214.28571428573994 257.14285714286" stroke="rgb(132, 0, 0)" fill="none" stroke-width="8.571428571428001px" stroke-linecap="round"/><path d="M 342.85714285715994 300 L 257.14285714287996 300" stroke="rgb(132, 0, 0)" fill="none" stroke-width="8.571428571428001px" stroke-linecap="round"/><circle cx="836.9300729065989" cy="298.52043118913207" r="8.571428571428001px" stroke-width="8.571428571428001px" fill="none" stroke="rgb(132, 0, 0)"/></g></svg>

--- a/tests/sch/not-connected-port.test.tsx
+++ b/tests/sch/not-connected-port.test.tsx
@@ -1,0 +1,68 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToSchematicSvg } from "lib/index"
+
+test("schematic not connected port", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      source_component_id: "src_comp1",
+      ftype: "simple_resistor",
+      name: "R1",
+      resistance: 1000,
+      display_resistance: "1kΩ",
+    },
+    {
+      type: "source_port",
+      source_port_id: "sp1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pin1"],
+      source_component_id: "src_comp1",
+      subcircuit_id: "sub0",
+    },
+    {
+      type: "source_port",
+      source_port_id: "sp2",
+      name: "pin2",
+      pin_number: 2,
+      port_hints: ["pin2"],
+      source_component_id: "src_comp1",
+      subcircuit_id: "sub0",
+    },
+    {
+      type: "schematic_component",
+      schematic_component_id: "sc1",
+      center: { x: 0, y: 0 },
+      size: { width: 1, height: 0.4 },
+      source_component_id: "src_comp1",
+      symbol_name: "boxresistor_right",
+      symbol_display_value: "1kΩ",
+    },
+    {
+      type: "schematic_port",
+      schematic_port_id: "scp1",
+      schematic_component_id: "sc1",
+      center: { x: -0.6, y: 0 },
+      source_port_id: "sp1",
+      facing_direction: "left",
+      distance_from_component_edge: 0.1,
+      pin_number: 1,
+      is_connected: false,
+    },
+    {
+      type: "schematic_port",
+      schematic_port_id: "scp2",
+      schematic_component_id: "sc1",
+      center: { x: 0.6, y: 0 },
+      source_port_id: "sp2",
+      facing_direction: "right",
+      distance_from_component_edge: 0.1,
+      pin_number: 2,
+    },
+  ]
+
+  expect(convertCircuitJsonToSchematicSvg(circuitJson)).toMatchSvgSnapshot(
+    import.meta.path,
+  )
+})


### PR DESCRIPTION
## Summary
- update `schematic-symbols` to latest
- add helper to render `not_connected_*` symbols
- draw not-connected symbols for ports
- don't draw dangling circle when `is_connected` is false
- test rendering of not-connected port

## Testing
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/sch/not-connected-port.test.tsx`
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/sch`

------
https://chatgpt.com/codex/tasks/task_b_6871a861a374832eb849e3a75fe15e45