### PR TITLE
Remove tscircuit peer dependency and mark it external

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start": "cosmos",
     "prepublish": "npm run build",
-    "build": "tsup-node ./lib/index.ts --format esm --dts --sourcemap",
+    "build": "tsup-node ./lib/index.ts --format esm --dts --sourcemap --external tscircuit",
     "format": "biome format . --write",
     "format:check": "biome format .",
     "cosmos": "cosmos",
@@ -34,9 +34,6 @@
     "tsup": "^8.0.2",
     "typescript": "^5.4.5",
     "vite-tsconfig-paths": "^5.0.1"
-  },
-  "peerDependencies": {
-    "tscircuit": "*"
   },
   "dependencies": {
     "@types/node": "^22.5.5",


### PR DESCRIPTION
## Summary
- remove the tscircuit peer dependency from the package manifest
- mark tscircuit as external in the tsup build command to prevent bundling it

## Testing
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_68e2068e64d0832ea4803eead601876f