### PR TITLE
fix: add source_trace_id hover highlighting fallback for traces missing connectivity key

### DIFF
--- a/lib/sch/convert-circuit-json-to-schematic-svg.ts
+++ b/lib/sch/convert-circuit-json-to-schematic-svg.ts
@@ -71,6 +71,26 @@ function buildNetHoverStyles(connectivityKeys: Set<string>): string {
   return rules.join("\n")
 }
 
+// Build CSS rules to highlight all traces sharing a source_trace_id
+// when any trace segment with the same source_trace_id is hovered.
+function buildSourceTraceHoverStyles(sourceTraceIds: Set<string>): string {
+  const rules: string[] = []
+  const esc = (v: string) => String(v).replace(/"/g, '\\"')
+  for (const id of sourceTraceIds) {
+    const k = esc(id)
+    const keyAttr = `[data-source-trace-id="${k}"]`
+    const baseSel = `g.trace${keyAttr}`
+    const overlaySel = `g.trace-overlays${keyAttr}`
+    const hovered = `:is(${baseSel}, ${overlaySel}):hover`
+    const target = `:is(${baseSel}, ${overlaySel})`
+    rules.push(`svg:has(${hovered}) ${target} { filter: invert(1); }`)
+    rules.push(
+      `svg:has(${hovered}) ${overlaySel} .trace-crossing-outline { opacity: 0; }`,
+    )
+  }
+  return rules.join("\n")
+}
+
 export function convertCircuitJsonToSchematicSvg(
   circuitJson: AnyCircuitElement[],
   options?: Options,
@@ -157,6 +177,7 @@ export function convertCircuitJsonToSchematicSvg(
   const schComponentSvgs: SvgObject[] = []
   const schTraceSvgs: SvgObject[] = []
   const connectivityKeys = new Set<string>()
+  const sourceTraceIds = new Set<string>()
   const schNetLabel: SvgObject[] = []
   const schText: SvgObject[] = []
   const voltageProbeSvgs: SvgObject[] = []
@@ -216,6 +237,7 @@ export function convertCircuitJsonToSchematicSvg(
         }),
       )
       connectivityKeys.add(elm.subcircuit_connectivity_map_key!)
+      if (elm.source_trace_id) sourceTraceIds.add(elm.source_trace_id)
     } else if (elm.type === "schematic_net_label") {
       schNetLabel.push(
         ...createSvgObjectsForSchNetLabel({
@@ -409,6 +431,8 @@ export function convertCircuitJsonToSchematicSvg(
                  invert color for all traces (base + overlays) sharing the same
                  subcircuit connectivity key. Also hide crossing outline during hover. */
               ${buildNetHoverStyles(connectivityKeys)}
+              /* Source trace hover: fallback highlighting by source_trace_id */
+              ${buildSourceTraceHoverStyles(sourceTraceIds)}
               .text { font-family: sans-serif; fill: ${colorMap.schematic.wire}; }
               .pin-number { fill: ${colorMap.schematic.pin_number}; }
               .port-label { fill: ${colorMap.schematic.reference}; }

--- a/lib/sch/svg-object-fns/create-svg-objects-from-sch-trace.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-from-sch-trace.ts
@@ -185,6 +185,9 @@ export function createSchematicTrace({
           "data-subcircuit-connectivity-map-key":
             trace.subcircuit_connectivity_map_key,
         }),
+        ...(trace.source_trace_id && {
+          "data-source-trace-id": trace.source_trace_id,
+        }),
       },
       children: baseObjects,
     },
@@ -200,6 +203,9 @@ export function createSchematicTrace({
         ...(trace.subcircuit_connectivity_map_key && {
           "data-subcircuit-connectivity-map-key":
             trace.subcircuit_connectivity_map_key,
+        }),
+        ...(trace.source_trace_id && {
+          "data-source-trace-id": trace.source_trace_id,
         }),
       },
       children: overlayObjects,


### PR DESCRIPTION
When schematic_trace elements lack subcircuit_connectivity_map_key, the existing net-hover CSS rules do not apply — related traces do not highlight together on hover.

This fix adds fallback hover highlighting grouped by source_trace_id.

**Changes:**
- `create-svg-objects-from-sch-trace.ts`: add `data-source-trace-id` attribute to both base and overlay trace group elements
- `convert-circuit-json-to-schematic-svg.ts`: add `buildSourceTraceHoverStyles()` function that generates CSS hover rules grouped by `source_trace_id`

**Result:** All schematic trace segments sharing the same `source_trace_id` now highlight together on hover, even when `subcircuit_connectivity_map_key` is absent.

Closes #549