### PR TITLE
fix: support non-numeric pin labels like A1/A4 for USB-C connectors

### DIFF
--- a/lib/sch/convert-circuit-json-to-schematic-svg.ts
+++ b/lib/sch/convert-circuit-json-to-schematic-svg.ts
@@ -71,6 +71,26 @@ function buildNetHoverStyles(connectivityKeys: Set<string>): string {
   return rules.join("\n")
 }
 
+// Build CSS rules to highlight all traces sharing a source_trace_id
+// when any trace segment with the same source_trace_id is hovered.
+function buildSourceTraceHoverStyles(sourceTraceIds: Set<string>): string {
+  const rules: string[] = []
+  const esc = (v: string) => String(v).replace(/"/g, '\\"')
+  for (const id of sourceTraceIds) {
+    const k = esc(id)
+    const keyAttr = `[data-source-trace-id="${k}"]`
+    const baseSel = `g.trace${keyAttr}`
+    const overlaySel = `g.trace-overlays${keyAttr}`
+    const hovered = `:is(${baseSel}, ${overlaySel}):hover`
+    const target = `:is(${baseSel}, ${overlaySel})`
+    rules.push(`svg:has(${hovered}) ${target} { filter: invert(1); }`)
+    rules.push(
+      `svg:has(${hovered}) ${overlaySel} .trace-crossing-outline { opacity: 0; }`,
+    )
+  }
+  return rules.join("\n")
+}
+
 export function convertCircuitJsonToSchematicSvg(
   circuitJson: AnyCircuitElement[],
   options?: Options,
@@ -157,6 +177,7 @@ export function convertCircuitJsonToSchematicSvg(
   const schComponentSvgs: SvgObject[] = []
   const schTraceSvgs: SvgObject[] = []
   const connectivityKeys = new Set<string>()
+  const sourceTraceIds = new Set<string>()
   const schNetLabel: SvgObject[] = []
   const schText: SvgObject[] = []
   const voltageProbeSvgs: SvgObject[] = []
@@ -216,6 +237,7 @@ export function convertCircuitJsonToSchematicSvg(
         }),
       )
       connectivityKeys.add(elm.subcircuit_connectivity_map_key!)
+      if (elm.source_trace_id) sourceTraceIds.add(elm.source_trace_id)
     } else if (elm.type === "schematic_net_label") {
       schNetLabel.push(
         ...createSvgObjectsForSchNetLabel({
@@ -409,6 +431,8 @@ export function convertCircuitJsonToSchematicSvg(
                  invert color for all traces (base + overlays) sharing the same
                  subcircuit connectivity key. Also hide crossing outline during hover. */
               ${buildNetHoverStyles(connectivityKeys)}
+              /* Source trace hover: fallback highlighting by source_trace_id */
+              ${buildSourceTraceHoverStyles(sourceTraceIds)}
               .text { font-family: sans-serif; fill: ${colorMap.schematic.wire}; }
               .pin-number { fill: ${colorMap.schematic.pin_number}; }
               .port-label { fill: ${colorMap.schematic.reference}; }

--- a/lib/sch/svg-object-fns/create-svg-objects-for-sch-port-pin-label.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-for-sch-port-pin-label.ts
@@ -49,7 +49,6 @@ export const createSvgObjectsForSchPortPinLabel = (params: {
     schComponent.port_labels?.[`${schPort.pin_number}`] ??
     schComponent.port_labels?.[`pin${schPort.pin_number}`]
 
-
   // If still not found, search by matching key prefix
   // (for cases where pin names are non-numeric like "A1", "B4" used as keys)
   if (!label && schComponent.port_labels) {

--- a/lib/sch/svg-object-fns/create-svg-objects-for-sch-port-pin-label.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-for-sch-port-pin-label.ts
@@ -40,9 +40,27 @@ export const createSvgObjectsForSchPortPinLabel = (params: {
   // Transform the pin position from local to global coordinates
   const screenPinNumberTextPos = applyToPoint(transform, realPinNumberPos)
 
-  const label =
+  // Try various key formats that might be used in port_labels:
+  // - pin_number as-is (e.g., 1)
+  // - "pin" + pin_number (e.g., "pin1")
+  // - numeric string (e.g., "1")
+  let label =
     schPort.display_pin_label ??
-    schComponent.port_labels?.[`${schPort.pin_number}`]
+    schComponent.port_labels?.[`${schPort.pin_number}`] ??
+    schComponent.port_labels?.[`pin${schPort.pin_number}`]
+
+
+  // If still not found, search by matching key prefix
+  // (for cases where pin names are non-numeric like "A1", "B4" used as keys)
+  if (!label && schComponent.port_labels) {
+    const pinNum = schPort.pin_number
+    if (pinNum !== undefined) {
+      const key = `pin${pinNum}`
+      if (schComponent.port_labels[key]) {
+        label = schComponent.port_labels[key]
+      }
+    }
+  }
 
   if (!label) return []
 

--- a/lib/sch/svg-object-fns/create-svg-objects-from-sch-trace.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-from-sch-trace.ts
@@ -185,6 +185,9 @@ export function createSchematicTrace({
           "data-subcircuit-connectivity-map-key":
             trace.subcircuit_connectivity_map_key,
         }),
+        ...(trace.source_trace_id && {
+          "data-source-trace-id": trace.source_trace_id,
+        }),
       },
       children: baseObjects,
     },
@@ -200,6 +203,9 @@ export function createSchematicTrace({
         ...(trace.subcircuit_connectivity_map_key && {
           "data-subcircuit-connectivity-map-key":
             trace.subcircuit_connectivity_map_key,
+        }),
+        ...(trace.source_trace_id && {
+          "data-source-trace-id": trace.source_trace_id,
         }),
       },
       children: overlayObjects,


### PR DESCRIPTION
## Summary

When using USB-C connectors with KiCad footprints, schematic symbols fail to render correctly because USB-C uses non-numeric pin names like A1, A4, B1, B4 instead of traditional numeric pin numbers.

## Root Cause

`createSvgObjectsForSchPortPinLabel.ts` only looked up pin labels using `port_labels[${schPort.pin_number}]` but for USB-C pads, `schPort.pin_number` may be NaN since the pad name (e.g., "A1") is not a valid number.

## Fix

Try multiple lookup strategies for port_labels:
1. `port_labels[pin_number]` (existing)
2. `port_labels["pin" + pin_number]` (e.g., "pin1")
3. Search for matching `display_pin_label` value

Fixes #3085