### PR TITLE
fix(pcb-bounds): tolerate route entries with nested start/end coords (unblocks pcb_trace rendering)

### DIFF
--- a/lib/pcb/get-pcb-bounds-from-circuit-json.ts
+++ b/lib/pcb/get-pcb-bounds-from-circuit-json.ts
@@ -406,15 +406,27 @@ export function getPcbBoundsFromCircuitJson(
 
   function updateTraceBounds(route: Point[]) {
     let updated = false
-    for (const point of route) {
-      const x = distance.parse(point?.x)
-      const y = distance.parse(point?.y)
-      if (x === undefined || y === undefined) continue
+    const tryUpdate = (px: unknown, py: unknown) => {
+      // distance.parse throws on undefined/null; guard before parsing
+      // so a single missing-coords route entry doesn't crash bounds
+      // computation for the entire circuit JSON.
+      if (px == null || py == null) return
+      const x = distance.parse(px)
+      const y = distance.parse(py)
+      if (x === undefined || y === undefined) return
       minX = Math.min(minX, x)
       minY = Math.min(minY, y)
       maxX = Math.max(maxX, x)
       maxY = Math.max(maxY, y)
       updated = true
+    }
+    for (const point of route) {
+      // Most route entries (wire, via) have top-level x/y. Some
+      // entries (e.g. through_obstacle) nest coordinates inside
+      // start/end objects instead — handle both.
+      tryUpdate((point as any)?.x, (point as any)?.y)
+      tryUpdate((point as any)?.start?.x, (point as any)?.start?.y)
+      tryUpdate((point as any)?.end?.x, (point as any)?.end?.y)
     }
     if (updated) {
       hasBounds = true

--- a/tests/pcb/pcb-trace-with-through-obstacle-renders.test.ts
+++ b/tests/pcb/pcb-trace-with-through-obstacle-renders.test.ts
@@ -1,0 +1,120 @@
+import { test, expect } from "bun:test"
+import { convertCircuitJsonToPcbSvg } from "lib"
+
+// Regression: route entries with `route_type: "through_obstacle"`
+// nest coordinates inside `start` / `end` objects rather than at the
+// top level. The pcb-bounds parser previously called distance.parse()
+// on `point.x` / `point.y` directly — which throws ZodError when the
+// values are undefined, crashing the entire renderer before any
+// trace (including those with no through_obstacle entries) got a
+// chance to draw.
+//
+// Expected behaviour for THIS fix: the bounds parser tolerates
+// missing top-level x/y, picks up coordinates from start/end if
+// present, and the SVG emits trace path elements for the wire and
+// via segments.
+//
+// Note: the trace renderer (createSvgObjectsFromPcbTrace) itself
+// also accesses `start.x` / `end.x` directly when forming SVG path
+// "d" attributes, so segments adjacent to a through_obstacle entry
+// will currently render with NaN coordinates. That's a separate
+// follow-up — fixing it requires picking the right nested coord
+// per pair direction (start.exit vs end.enter). The bounds-crash
+// fix here unblocks rendering for routes WITHOUT through_obstacle
+// entries (the common case for plain wire+via traces).
+test("pcb_trace with through_obstacle route entries does not crash bounds parser", () => {
+  const circuitJson: any[] = [
+    {
+      type: "pcb_board",
+      pcb_board_id: "pcb_board_0",
+      center: { x: 0, y: 0 },
+      width: 20,
+      height: 20,
+      thickness: 1.6,
+      num_layers: 4,
+    },
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "pcb_trace_0",
+      source_trace_id: "source_trace_0",
+      route: [
+        { route_type: "wire", x: -5, y: 0, layer: "top", width: 0.15 },
+        { route_type: "wire", x: -2, y: 0, layer: "top", width: 0.15 },
+        // through_obstacle nests coords inside start/end. Used to
+        // crash distance.parse(point.x) for point = this entry.
+        {
+          route_type: "through_obstacle",
+          start: { x: -2, y: 0 },
+          end: { x: -2, y: 0 },
+          from_layer: "top",
+          to_layer: "bottom",
+          width: 0.15,
+        },
+        { route_type: "wire", x: -2, y: 0, layer: "bottom", width: 0.15 },
+        { route_type: "wire", x: 5, y: 0, layer: "bottom", width: 0.15 },
+      ],
+    },
+  ]
+
+  // Must not throw.
+  const svg = convertCircuitJsonToPcbSvg(circuitJson as any)
+
+  // At least one pcb_trace path element must be emitted (the wire
+  // segments before/after the through_obstacle).
+  const numTracePaths = (svg.match(/data-type="pcb_trace"/g) || []).length
+  expect(numTracePaths).toBeGreaterThan(0)
+})
+
+// Pure wire+via routes (the common case, no through_obstacle entries)
+// also crashed under the old bounds parser if ANY OTHER pcb_trace in
+// the same circuit had a through_obstacle entry — bounds is computed
+// across all elements and one bad route point throws for everyone.
+// This test confirms a clean wire+via route renders even when a
+// sibling trace contains through_obstacle entries.
+test("clean wire+via traces still render alongside through_obstacle routes", () => {
+  const circuitJson: any[] = [
+    {
+      type: "pcb_board",
+      pcb_board_id: "pcb_board_0",
+      center: { x: 0, y: 0 },
+      width: 20,
+      height: 20,
+      thickness: 1.6,
+      num_layers: 4,
+    },
+    {
+      // Plain wire trace — no through_obstacle, no special data shape.
+      type: "pcb_trace",
+      pcb_trace_id: "pcb_trace_clean",
+      source_trace_id: "source_trace_clean",
+      route: [
+        { route_type: "wire", x: -5, y: -3, layer: "top", width: 0.15 },
+        { route_type: "wire", x: 5, y: -3, layer: "top", width: 0.15 },
+      ],
+    },
+    {
+      // Sibling trace containing a through_obstacle. Used to crash
+      // the whole renderer.
+      type: "pcb_trace",
+      pcb_trace_id: "pcb_trace_with_throughobstacle",
+      source_trace_id: "source_trace_through",
+      route: [
+        { route_type: "wire", x: -5, y: 3, layer: "top", width: 0.15 },
+        {
+          route_type: "through_obstacle",
+          start: { x: -5, y: 3 },
+          end: { x: -5, y: 3 },
+          from_layer: "top",
+          to_layer: "bottom",
+          width: 0.15,
+        },
+        { route_type: "wire", x: 5, y: 3, layer: "bottom", width: 0.15 },
+      ],
+    },
+  ]
+
+  const svg = convertCircuitJsonToPcbSvg(circuitJson as any)
+
+  // Clean wire trace emits its segment path.
+  expect(svg.match(/data-type="pcb_trace"/g)?.length).toBeGreaterThan(0)
+})


### PR DESCRIPTION
## Summary

`updateTraceBounds` in `getPcbBoundsFromCircuitJson` was calling `distance.parse(point.x)` and `distance.parse(point.y)` directly on each route entry. zod throws `ZodError` when the value is undefined — so any `pcb_trace` containing a route entry without top-level x/y (e.g. `route_type: "through_obstacle"`, which nests its coordinates inside `start` / `end` objects) crashed the entire bounds parser, and therefore the entire renderer, before ANY trace got a chance to draw.

**Symptom:** a circuit with 38 `pcb_trace` records produced 0 trace path elements in the SVG output, even for the 35 traces that contained only `wire` and `via` route entries (no `through_obstacle`). The `through_obstacle` entries in 3 of the 38 traces were enough to crash bounds for all of them.

## Fix

Skip route points without valid x/y, and pick up nested `start.x`/`start.y` and `end.x`/`end.y` so `through_obstacle` entries contribute their actual coordinates to the bounding box (instead of being silently ignored once they're not crashing things):

```ts
function updateTraceBounds(route: Point[]) {
  let updated = false
  const tryUpdate = (px: unknown, py: unknown) => {
    if (px == null || py == null) return
    const x = distance.parse(px)
    const y = distance.parse(py)
    if (x === undefined || y === undefined) return
    minX = Math.min(minX, x); /* ... */
    updated = true
  }
  for (const point of route) {
    tryUpdate((point as any)?.x, (point as any)?.y)
    tryUpdate((point as any)?.start?.x, (point as any)?.start?.y)
    tryUpdate((point as any)?.end?.x, (point as any)?.end?.y)
  }
  if (updated) hasBounds = true
}
```

## Test plan

- [x] All 203 existing tests pass unchanged
- [x] New `tests/pcb/pcb-trace-with-through-obstacle-renders.test.ts`:
   - through_obstacle in a route doesn't throw, emits trace paths
   - clean wire+via route in the same circuit also renders (the crash previously took out sibling traces)
- [x] `bun test`: 205 pass total
- [x] `biome format`: clean

## What this DOESN'T fix (separate follow-up)

`createSvgObjectsFromPcbTrace` itself still accesses `start.x` / `end.x` directly when building SVG path `d` attributes, so SVG segments *adjacent to* a `through_obstacle` entry currently render with `NaN` coordinates. Fixing it requires picking the right nested coord per pair direction (start vs end of the obstacle for incoming vs outgoing segments).

The bounds-crash fix here unblocks rendering for the common case (routes without `through_obstacle` entries) — which is the majority of autorouter output. A follow-up PR should fix the trace renderer itself for the through_obstacle case.

## Repro

A 24 × 22 mm 2-layer ISP3080-UX daughter board with the autorouter producing 38 `pcb_traces`, 3 of which contained `through_obstacle` entries from layer transitions through copper pour. Visually, all 38 traces were missing from `tsci snapshot --pcb-only`. After this fix, 35/38 render correctly (the 3 with through_obstacle still have NaN-coord segments pending the renderer follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
