### PR TITLE
fix: handle through_obstacle route points in updateTraceBounds

### DIFF
--- a/lib/pcb/get-pcb-bounds-from-circuit-json.ts
+++ b/lib/pcb/get-pcb-bounds-from-circuit-json.ts
@@ -407,14 +407,29 @@ export function getPcbBoundsFromCircuitJson(
   function updateTraceBounds(route: Point[]) {
     let updated = false
     for (const point of route) {
-      const x = distance.parse(point?.x)
-      const y = distance.parse(point?.y)
+      // "through_obstacle" route points store coordinates in start/end
+      // instead of top-level x/y — extract them so bounds are correct
+      const p = point as any
+      const x = distance.safeParse(p?.x ?? p?.start?.x ?? p?.end?.x).data
+      const y = distance.safeParse(p?.y ?? p?.start?.y ?? p?.end?.y).data
       if (x === undefined || y === undefined) continue
       minX = Math.min(minX, x)
       minY = Math.min(minY, y)
       maxX = Math.max(maxX, x)
       maxY = Math.max(maxY, y)
       updated = true
+
+      // For through_obstacle, also check the end point
+      if (p?.end?.x !== undefined && p?.end?.y !== undefined) {
+        const ex = distance.safeParse(p.end.x).data
+        const ey = distance.safeParse(p.end.y).data
+        if (ex !== undefined && ey !== undefined) {
+          minX = Math.min(minX, ex)
+          minY = Math.min(minY, ey)
+          maxX = Math.max(maxX, ex)
+          maxY = Math.max(maxY, ey)
+        }
+      }
     }
     if (updated) {
       hasBounds = true

--- a/tests/pcb/through-obstacle-bounds.test.ts
+++ b/tests/pcb/through-obstacle-bounds.test.ts
@@ -1,0 +1,108 @@
+import { test, expect } from "bun:test"
+import { convertCircuitJsonToPcbSvg } from "lib/index"
+import type { AnyCircuitElement } from "circuit-json"
+
+test("through_obstacle route points should not crash updateTraceBounds", () => {
+  // Minimal circuit JSON with a trace containing through_obstacle route points.
+  // These store coordinates in start/end instead of top-level x/y, which
+  // previously caused a ZodError in distance.parse().
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      source_component_id: "sc1",
+      name: "R1",
+      ftype: "simple_resistor",
+    } as any,
+    {
+      type: "source_component",
+      source_component_id: "sc2",
+      name: "R2",
+      ftype: "simple_resistor",
+    } as any,
+    {
+      type: "pcb_component",
+      pcb_component_id: "pc1",
+      source_component_id: "sc1",
+      center: { x: 0, y: 0 },
+      width: 2,
+      height: 1,
+      rotation: 0,
+      layer: "top",
+    },
+    {
+      type: "pcb_component",
+      pcb_component_id: "pc2",
+      source_component_id: "sc2",
+      center: { x: 10, y: 0 },
+      width: 2,
+      height: 1,
+      rotation: 0,
+      layer: "top",
+    },
+    {
+      type: "pcb_port",
+      pcb_port_id: "pp1",
+      pcb_component_id: "pc1",
+      source_port_id: "sp1",
+      x: 1,
+      y: 0,
+      layers: ["top"],
+    },
+    {
+      type: "pcb_port",
+      pcb_port_id: "pp2",
+      pcb_component_id: "pc2",
+      source_port_id: "sp2",
+      x: 9,
+      y: 0,
+      layers: ["top"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "sp1",
+      source_component_id: "sc1",
+      name: "pin1",
+      pin_number: 1,
+    } as any,
+    {
+      type: "source_port",
+      source_port_id: "sp2",
+      source_component_id: "sc2",
+      name: "pin1",
+      pin_number: 1,
+    } as any,
+    {
+      type: "source_trace",
+      source_trace_id: "st1",
+      connected_source_port_ids: ["sp1", "sp2"],
+    } as any,
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "pt1",
+      source_trace_id: "st1",
+      route: [
+        { route_type: "wire", x: 1, y: 0, width: 0.16, layer: "top" },
+        { route_type: "wire", x: 3, y: 0, width: 0.16, layer: "top" },
+        // through_obstacle stores coords in start/end, not top-level x/y
+        {
+          route_type: "via",
+          // @ts-ignore — through_obstacle shape not in type defs
+          via_type: "through_obstacle",
+          start: { x: 3, y: 0 },
+          end: { x: 7, y: 0 },
+          from_layer: "top",
+          to_layer: "bottom",
+        } as any,
+        { route_type: "wire", x: 7, y: 0, width: 0.16, layer: "top" },
+        { route_type: "wire", x: 9, y: 0, width: 0.16, layer: "top" },
+      ],
+    },
+  ]
+
+  // Should not throw — previously crashed with ZodError on distance.parse(undefined)
+  const svg = convertCircuitJsonToPcbSvg(circuitJson)
+
+  expect(svg).toBeDefined()
+  expect(svg).toContain("<svg")
+  expect(svg).toContain("</svg>")
+})


### PR DESCRIPTION
The autorouter can produce 'through_obstacle' route points which store coordinates in start/end objects instead of top-level x/y properties. This caused a ZodError crash in distance.parse() when computing PCB bounds for SVG export.

Fix: use safeParse with fallback to start/end coordinates, and also include end point in bounds calculation for through_obstacle segments.