### PR TITLE
Support custom styling for schematics

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ const schematicSvg = convertCircuitJsonToSchematicSvg(circuitJson, {
 - `grid` – enable a schematic grid (`true`) or configure cell size and labels.
 - `labeledPoints` – annotate specific coordinates with helper labels.
 - `colorOverrides` – override portions of the schematic color palette.
+- `className` – add one or more extra classes to the root schematic `<svg>`.
+- `css` – append custom CSS to the generated schematic SVG.
 - `includeVersion` – if `true`, add a `data-circuit-to-svg-version` attribute to
   the root `<svg>`.
 

--- a/lib/sch/convert-circuit-json-to-schematic-svg.ts
+++ b/lib/sch/convert-circuit-json-to-schematic-svg.ts
@@ -47,6 +47,8 @@ interface Options {
   includeVersion?: boolean
   showErrorsInTextOverlay?: boolean
   drawPorts?: boolean
+  css?: string
+  className?: string
 }
 
 // Build CSS rules to highlight all traces sharing a connectivity key
@@ -367,6 +369,9 @@ export function convertCircuitJsonToSchematicSvg(
     type: "element",
     attributes: {
       xmlns: "http://www.w3.org/2000/svg",
+      class: ["tscircuit-schematic", options?.className]
+        .filter(Boolean)
+        .join(" "),
       width: svgWidth.toString(),
       height: svgHeight.toString(),
       style: `background-color: ${colorMap.schematic.background}`,
@@ -413,6 +418,7 @@ export function convertCircuitJsonToSchematicSvg(
               .pin-number { fill: ${colorMap.schematic.pin_number}; }
               .port-label { fill: ${colorMap.schematic.reference}; }
               .component-name { fill: ${colorMap.schematic.reference}; }
+              ${options?.css ?? ""}
             `,
             name: "",
             attributes: {},

--- a/lib/sch/draw-schematic-grid.ts
+++ b/lib/sch/draw-schematic-grid.ts
@@ -108,7 +108,7 @@ export function drawSchematicGrid(params: {
     name: "g",
     value: "",
     type: "element",
-    attributes: { class: "grid" },
+    attributes: { class: "grid sch-grid" },
     children: gridLines,
   }
 }

--- a/lib/sch/draw-schematic-labeled-points.ts
+++ b/lib/sch/draw-schematic-labeled-points.ts
@@ -70,7 +70,7 @@ export function drawSchematicLabeledPoints(params: {
     name: "g",
     value: "",
     type: "element",
-    attributes: { class: "labeled-points" },
+    attributes: { class: "labeled-points sch-labeled-points" },
     children: labeledPointsGroup,
   }
 }

--- a/lib/sch/svg-object-fns/create-svg-objects-for-sch-net-label-with-symbol.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-for-sch-net-label-with-symbol.ts
@@ -164,7 +164,7 @@ export const createSvgObjectsForSchNetLabelWithSymbol = ({
     type: "element",
     value: "",
     attributes: {
-      class: "component-overlay",
+      class: "component-overlay sch-component-overlay sch-net-label-overlay",
       x: rectX.toString(),
       y: rectY.toString(),
       width: rectWidth.toString(),
@@ -190,6 +190,7 @@ export const createSvgObjectsForSchNetLabelWithSymbol = ({
       name: "path",
       type: "element",
       attributes: {
+        class: "sch-net-label-symbol-path",
         d: symbolPath + (path.closed ? " Z" : ""),
         stroke: colorMap.schematic.component_outline,
         fill: "none",
@@ -232,6 +233,7 @@ export const createSvgObjectsForSchNetLabelWithSymbol = ({
       name: "text",
       type: "element",
       attributes: {
+        class: "sch-net-label-symbol-text",
         x: offsetScreenPos.x.toString(),
         y: offsetScreenPos.y.toString(),
         fill: colorMap.schematic.label_local,
@@ -270,6 +272,7 @@ export const createSvgObjectsForSchNetLabelWithSymbol = ({
       name: "rect",
       type: "element",
       attributes: {
+        class: "sch-net-label-symbol-box",
         x: screenBoxPos.x.toString(),
         y: screenBoxPos.y.toString(),
         width: (box.width * symbolToScreenScale).toString(),
@@ -296,6 +299,7 @@ export const createSvgObjectsForSchNetLabelWithSymbol = ({
       name: "circle",
       type: "element",
       attributes: {
+        class: "sch-net-label-symbol-circle",
         cx: screenCirclePos.x.toString(),
         cy: screenCirclePos.y.toString(),
         r: (circle.radius * symbolToScreenScale).toString(),

--- a/lib/sch/svg-object-fns/create-svg-objects-for-sch-net-label.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-for-sch-net-label.ts
@@ -155,7 +155,7 @@ export const createSvgObjectsForSchNetLabel = ({
     name: "path",
     type: "element",
     attributes: {
-      class: "net-label",
+      class: "net-label sch-net-label",
       d: pathD,
       fill: colorMap.schematic.label_background,
       stroke: colorMap.schematic.label_global,
@@ -189,7 +189,7 @@ export const createSvgObjectsForSchNetLabel = ({
     name: "text",
     type: "element",
     attributes: {
-      class: "net-label-text",
+      class: "net-label-text sch-net-label-text",
       x: screenTextPos.x.toString(),
       y: screenTextPos.y.toString(),
       fill: colorMap.schematic.label_global,

--- a/lib/sch/svg-object-fns/create-svg-objects-for-sch-port-box-line.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-for-sch-port-box-line.ts
@@ -145,7 +145,7 @@ export const createSvgObjectsForSchPortBoxLine = ({
       name: "circle",
       type: "element",
       attributes: {
-        class: "component-pin",
+        class: "component-pin sch-component-pin sch-inversion-bubble",
         cx: bubbleCenter.x.toString(),
         cy: bubbleCenter.y.toString(),
         r: bubbleRadiusPx.toString(),
@@ -163,7 +163,7 @@ export const createSvgObjectsForSchPortBoxLine = ({
     name: "line",
     type: "element",
     attributes: {
-      class: "component-pin",
+      class: "component-pin sch-component-pin sch-port-line",
       x1: screenRealEdgePos.x.toString(),
       y1: screenRealEdgePos.y.toString(),
       x2: screenLineEnd.x.toString(),
@@ -182,7 +182,7 @@ export const createSvgObjectsForSchPortBoxLine = ({
       name: "circle",
       type: "element",
       attributes: {
-        class: "component-pin",
+        class: "component-pin sch-component-pin sch-port-terminal",
         cx: screenSchPortPos.x.toString(),
         cy: screenSchPortPos.y.toString(),
         r: pinRadiusPx.toString(),
@@ -212,6 +212,7 @@ export const createSvgObjectsForSchPortBoxLine = ({
     type: "element",
     value: "",
     attributes: {
+      class: "sch-port",
       "data-schematic-port-id": schPort.source_port_id,
     },
     children: pinChildren,

--- a/lib/sch/svg-object-fns/create-svg-objects-for-sch-port-hover.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-for-sch-port-hover.ts
@@ -25,7 +25,7 @@ export const createSvgObjectsForSchPortHover = ({
       type: "element",
       value: "",
       attributes: {
-        class: "schematic-port-hover",
+        class: "schematic-port-hover sch-port-hover",
         "data-schematic-port-id": schPort.source_port_id,
       },
       children: [

--- a/lib/sch/svg-object-fns/create-svg-objects-for-sch-port-indicator.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-for-sch-port-indicator.ts
@@ -33,7 +33,7 @@ export const createSvgObjectsForSchPortIndicator = ({
     type: "element",
     value: "",
     attributes: {
-      class: "component-pin",
+      class: "component-pin sch-component-pin sch-port-indicator",
       cx: screenPos.x.toString(),
       cy: screenPos.y.toString(),
       r: radiusPx.toString(),
@@ -102,7 +102,7 @@ export const createSvgObjectsForSchPortIndicator = ({
       type: "element",
       value: "",
       attributes: {
-        class: "port-indicator-label",
+        class: "port-indicator-label sch-port-label",
         x: screenLabelPos.x.toString(),
         y: screenLabelPos.y.toString(),
         fill: colorMap.schematic.component_outline,

--- a/lib/sch/svg-object-fns/create-svg-objects-for-sch-port-pin-label.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-for-sch-port-pin-label.ts
@@ -62,7 +62,7 @@ export const createSvgObjectsForSchPortPinLabel = (params: {
     name: "text",
     type: "element",
     attributes: {
-      class: "pin-number",
+      class: "pin-number sch-pin-label",
       x: screenPinNumberTextPos.x.toString(),
       y: screenPinNumberTextPos.y.toString(),
       style: `font-family: sans-serif;${isNegated ? " text-decoration: overline;" : ""}`,

--- a/lib/sch/svg-object-fns/create-svg-objects-for-sch-port-pin-number-text.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-for-sch-port-pin-number-text.ts
@@ -51,7 +51,7 @@ export const createSvgObjectsForSchPortPinNumberText = (params: {
     name: "text",
     type: "element",
     attributes: {
-      class: "pin-number",
+      class: "pin-number sch-pin-number",
       x: screenPinNumberTextPos.x.toString(),
       y: screenPinNumberTextPos.y.toString(),
       style: "font-family: sans-serif;",

--- a/lib/sch/svg-object-fns/create-svg-objects-for-sch-reference-designators.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-for-sch-reference-designators.ts
@@ -176,7 +176,7 @@ export const createSvgObjectsForSchReferenceDesignators = ({
           "text-anchor": ninePointAnchorToTextAnchor[text.anchor],
           "dominant-baseline": dominantBaseline,
           "font-size": `${getSchScreenFontSize(realToScreenTransform, "reference_designator")}px`,
-          class: "component-name",
+          class: "component-name sch-component-name",
           "data-schematic-component-id": schComponent.schematic_component_id,
         },
         value: "",

--- a/lib/sch/svg-object-fns/create-svg-objects-for-sch-text.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-for-sch-text.ts
@@ -115,6 +115,7 @@ export const createSvgSchText = ({
     name: "text",
     value: "",
     attributes: {
+      class: "sch-text",
       x: center.x.toString(),
       y: center.y.toString(),
       fill: elm.color ?? colorMap.schematic.sheet_label,

--- a/lib/sch/svg-object-fns/create-svg-objects-from-sch-arc.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-from-sch-arc.ts
@@ -50,6 +50,7 @@ export function createSvgObjectsFromSchematicArc({
       name: "path",
       type: "element",
       attributes: {
+        class: "sch-arc",
         d: pathData,
         fill: "none",
         stroke: schArc.color,

--- a/lib/sch/svg-object-fns/create-svg-objects-from-sch-box.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-from-sch-box.ts
@@ -29,7 +29,7 @@ export const createSvgObjectsFromSchematicBox = ({
 
   const strokeWidthPx = getSchStrokeSize(transform)
   const attributes: Record<string, string> = {
-    class: "schematic-box",
+    class: "schematic-box sch-box",
     x: xLeft.toString(),
     y: yTop.toString(),
     width: (xRight - xLeft).toString(),

--- a/lib/sch/svg-object-fns/create-svg-objects-from-sch-circle.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-from-sch-circle.ts
@@ -24,6 +24,7 @@ export function createSvgObjectsFromSchematicCircle({
       name: "circle",
       type: "element",
       attributes: {
+        class: "sch-circle",
         cx: center.x.toString(),
         cy: center.y.toString(),
         r: transformedRadius.toString(),

--- a/lib/sch/svg-object-fns/create-svg-objects-from-sch-component-with-box.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-from-sch-component-with-box.ts
@@ -48,7 +48,7 @@ export const createSvgObjectsFromSchematicComponentWithBox = ({
     type: "element",
     value: "",
     attributes: {
-      class: "component chip",
+      class: "component chip sch-component-body",
       x: componentScreenTopLeft.x.toString(),
       y: componentScreenTopLeft.y.toString(),
       width: componentScreenWidth.toString(),
@@ -65,7 +65,7 @@ export const createSvgObjectsFromSchematicComponentWithBox = ({
     type: "element",
     value: "",
     attributes: {
-      class: "component-overlay",
+      class: "component-overlay sch-component-overlay",
       x: componentScreenTopLeft.x.toString(),
       y: componentScreenTopLeft.y.toString(),
       width: componentScreenWidth.toString(),

--- a/lib/sch/svg-object-fns/create-svg-objects-from-sch-component-with-symbol.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-from-sch-component-with-symbol.ts
@@ -144,7 +144,7 @@ export const createSvgObjectsFromSchematicComponentWithSymbol = ({
     type: "element",
     value: "",
     attributes: {
-      class: "component-overlay",
+      class: "component-overlay sch-component-overlay",
       x: rectX.toString(),
       y: rectY.toString(),
       width: rectWidth.toString(),
@@ -159,6 +159,7 @@ export const createSvgObjectsFromSchematicComponentWithSymbol = ({
       type: "element",
       name: "path",
       attributes: {
+        class: "sch-component-symbol-path",
         d:
           points
             .map((p, i) => {
@@ -199,6 +200,9 @@ export const createSvgObjectsFromSchematicComponentWithSymbol = ({
       name: "text",
       type: "element",
       attributes: {
+        class: isReferenceText
+          ? "sch-component-name sch-component-text"
+          : "sch-component-text",
         x: screenTextPos.x.toString(),
         y: screenTextPos.y.toString(),
         ...(isReferenceText
@@ -243,6 +247,7 @@ export const createSvgObjectsFromSchematicComponentWithSymbol = ({
       name: "rect",
       type: "element",
       attributes: {
+        class: "sch-component-symbol-box",
         x: screenBoxPos.x.toString(),
         y: screenBoxPos.y.toString(),
         width: (box.width * symbolToScreenScale).toString(),
@@ -265,6 +270,7 @@ export const createSvgObjectsFromSchematicComponentWithSymbol = ({
       type: "element",
       name: "circle",
       attributes: {
+        class: "component-pin sch-component-pin",
         cx: screenPortPos.x.toString(),
         cy: screenPortPos.y.toString(),
         r: `${Math.abs(realToScreenTransform.a) * 0.02}px`,
@@ -287,6 +293,7 @@ export const createSvgObjectsFromSchematicComponentWithSymbol = ({
       type: "element",
       name: "circle",
       attributes: {
+        class: "sch-component-symbol-circle",
         cx: screenCirclePos.x.toString(),
         cy: screenCirclePos.y.toString(),
         r: `${screenRadius}px`,

--- a/lib/sch/svg-object-fns/create-svg-objects-from-sch-component.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-from-sch-component.ts
@@ -36,6 +36,7 @@ export function createSvgObjectsFromSchematicComponent(params: {
       type: "element",
       name: "g",
       attributes: {
+        class: "sch-component",
         "data-circuit-json-type": "schematic_component",
         "data-schematic-component-id": component.schematic_component_id,
       },

--- a/lib/sch/svg-object-fns/create-svg-objects-from-sch-line.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-from-sch-line.ts
@@ -32,6 +32,7 @@ export function createSvgObjectsFromSchematicLine({
       name: "line",
       type: "element",
       attributes: {
+        class: "sch-line",
         x1: p1.x.toString(),
         y1: p1.y.toString(),
         x2: p2.x.toString(),

--- a/lib/sch/svg-object-fns/create-svg-objects-from-sch-path.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-from-sch-path.ts
@@ -45,6 +45,7 @@ export function createSvgObjectsFromSchematicPath({
       name: "path",
       type: "element",
       attributes: {
+        class: "sch-path",
         d: pathD,
         stroke: strokeColor,
         "stroke-width": transformedStrokeWidth.toString(),

--- a/lib/sch/svg-object-fns/create-svg-objects-from-sch-rect.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-from-sch-rect.ts
@@ -28,6 +28,7 @@ export function createSvgObjectsFromSchematicRect({
     name: "rect",
     type: "element",
     attributes: {
+      class: "sch-rect",
       x: x.toString(),
       y: y.toString(),
       width: transformedWidth.toString(),

--- a/lib/sch/svg-object-fns/create-svg-objects-from-sch-table.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-from-sch-table.ts
@@ -70,6 +70,7 @@ export const createSvgObjectsFromSchematicTable = ({
     name: "rect",
     type: "element",
     attributes: {
+      class: "sch-table-border",
       x: screenTopLeftX.toString(),
       y: screenTopLeftY.toString(),
       width: (screenBottomRightX - screenTopLeftX).toString(),
@@ -110,6 +111,7 @@ export const createSvgObjectsFromSchematicTable = ({
           name: "line",
           type: "element",
           attributes: {
+            class: "sch-table-grid-line",
             x1: start.x.toString(),
             y1: start.y.toString(),
             x2: end.x.toString(),
@@ -149,6 +151,7 @@ export const createSvgObjectsFromSchematicTable = ({
           name: "line",
           type: "element",
           attributes: {
+            class: "sch-table-grid-line",
             x1: start.x.toString(),
             y1: start.y.toString(),
             x2: end.x.toString(),
@@ -237,6 +240,7 @@ export const createSvgObjectsFromSchematicTable = ({
         name: "text",
         type: "element",
         attributes: {
+          class: "sch-table-text",
           x: screenTextAnchorPos.x.toString(),
           y: screenTextAnchorPos.y.toString(),
           "font-size": `${fontSize}px`,
@@ -264,6 +268,7 @@ export const createSvgObjectsFromSchematicTable = ({
       name: "g",
       type: "element",
       attributes: {
+        class: "sch-table",
         "data-schematic-table-id": schematicTable.schematic_table_id,
       },
       children: svgObjects,

--- a/lib/sch/svg-object-fns/create-svg-objects-from-sch-trace.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-from-sch-trace.ts
@@ -55,7 +55,7 @@ export function createSchematicTrace({
       type: "element",
       attributes: {
         d: path,
-        class: "trace-invisible-hover-outline",
+        class: "trace-invisible-hover-outline sch-trace-hitbox",
         stroke: colorMap.schematic.wire,
         fill: "none",
         "stroke-width": `${getSchStrokeSize(transform) * 8}px`,
@@ -70,6 +70,7 @@ export function createSchematicTrace({
       name: "path",
       type: "element",
       attributes: {
+        class: "sch-trace-path",
         d: path,
         stroke: colorMap.schematic.wire,
         fill: "none",
@@ -120,7 +121,7 @@ export function createSchematicTrace({
       name: "path",
       type: "element",
       attributes: {
-        class: "trace-crossing-outline",
+        class: "trace-crossing-outline sch-trace-crossing-outline",
         d: `M ${screenFromX} ${screenFromY} Q ${controlX} ${controlY} ${screenToX} ${screenToY}`,
         stroke: colorMap.schematic.background,
         fill: "none",
@@ -135,6 +136,7 @@ export function createSchematicTrace({
       name: "path",
       type: "element",
       attributes: {
+        class: "sch-trace-crossing-path",
         d: `M ${screenFromX} ${screenFromY} Q ${controlX} ${controlY} ${screenToX} ${screenToY}`,
         stroke: colorMap.schematic.wire,
         fill: "none",
@@ -161,7 +163,7 @@ export function createSchematicTrace({
           cx: screenX.toString(),
           cy: screenY.toString(),
           r: (Math.abs(transform.a) * 0.03).toString(),
-          class: "trace-junction",
+          class: "trace-junction sch-trace-junction",
           fill: colorMap.schematic.junction,
         },
         value: "",
@@ -177,7 +179,7 @@ export function createSchematicTrace({
       type: "element",
       value: "",
       attributes: {
-        class: "trace",
+        class: "trace sch-trace",
         "data-layer": "base",
         "data-circuit-json-type": "schematic_trace",
         "data-schematic-trace-id": trace.schematic_trace_id,
@@ -193,7 +195,7 @@ export function createSchematicTrace({
       type: "element",
       value: "",
       attributes: {
-        class: "trace-overlays",
+        class: "trace-overlays sch-trace-overlays",
         "data-layer": "overlay",
         "data-circuit-json-type": "schematic_trace",
         "data-schematic-trace-id": trace.schematic_trace_id,

--- a/lib/sch/svg-object-fns/create-svg-objects-from-sch-voltage-probe.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-from-sch-voltage-probe.ts
@@ -173,6 +173,7 @@ export function createSvgObjectsFromSchVoltageProbe({
       name: "path",
       type: "element",
       attributes: {
+        class: "sch-voltage-probe",
         d: arrowPath,
         stroke: probeColor,
         fill: probeColor,
@@ -186,6 +187,7 @@ export function createSvgObjectsFromSchVoltageProbe({
       name: "text",
       value: "",
       attributes: {
+        class: "sch-voltage-probe-label",
         x,
         y,
         fill: probeColor,

--- a/tests/sch/__snapshots__/schematic-css-api.snap.svg
+++ b/tests/sch/__snapshots__/schematic-css-api.snap.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="tscircuit-schematic custom-theme" width="1200" height="600" style="background-color: rgb(245, 241, 237)" data-real-to-screen-transform="matrix(333.3333333333,0,0,-333.3333333333,600,300)"><style>
+              .boundary { fill: rgb(245, 241, 237); }
+              .schematic-boundary { fill: none; stroke: #fff; }
+              .component { fill: none; stroke: rgb(132, 0, 0); }
+              .chip { fill: rgb(255, 255, 194); stroke: rgb(132, 0, 0); }
+              .component-pin { fill: none; stroke: rgb(132, 0, 0); }
+              /* Basic per-trace hover fallback */
+              .trace:hover {
+                filter: invert(1);
+              }
+              .trace:hover .trace-crossing-outline {
+                opacity: 0;
+              }
+              .trace:hover .trace-junction {
+                filter: invert(1);
+              }
+              /* Net-hover highlighting: when a trace or its overlays are hovered,
+                 invert color for all traces (base + overlays) sharing the same
+                 subcircuit connectivity key. Also hide crossing outline during hover. */
+              
+              .text { font-family: sans-serif; fill: rgb(0, 150, 0); }
+              .pin-number { fill: rgb(169, 0, 0); }
+              .port-label { fill: rgb(0, 100, 100); }
+              .component-name { fill: rgb(0, 100, 100); }
+              
+        .custom-theme .sch-component-body {
+          fill: #c7d2fe !important;
+          stroke: #4338ca !important;
+        }
+      
+            </style><rect class="boundary" x="0" y="0" width="1200" height="600"/><g class="sch-component" data-circuit-json-type="schematic_component" data-schematic-component-id="sch_comp_1"><rect class="component chip sch-component-body" x="333.33333333336" y="166.66666666668" width="533.33333333328" height="266.66666666664" stroke-width="6.666666666666px" fill="rgb(255, 255, 194)" stroke="rgb(132, 0, 0)"/><rect class="component-overlay sch-component-overlay" x="333.33333333336" y="166.66666666668" width="533.33333333328" height="266.66666666664" fill="transparent"/><circle class="component-pin sch-component-pin sch-inversion-bubble" cx="313.333333333362" cy="300" r="19.999999999998" fill="white" stroke="rgb(132, 0, 0)" stroke-width="6.666666666666px"/><line class="component-pin sch-component-pin sch-port-line" x1="293.333333333364" y1="300" x2="206.66666666670602" y2="300" stroke-width="6.666666666666px"/><g class="sch-port" data-schematic-port-id="src_port_3"><circle class="component-pin sch-component-pin sch-port-terminal" cx="200.00000000004002" cy="300" r="6.666666666666" stroke-width="6.666666666666px"/><rect x="193.33333333337401" y="293.333333333334" width="13.333333333332" height="13.333333333332" opacity="0"/></g><text class="pin-number sch-pin-number" x="266.6666666667" y="293.333333333334" style="font-family: sans-serif;" fill="rgb(169, 0, 0)" text-anchor="middle" dominant-baseline="auto" font-size="49.999999999995px" transform=""></text><text class="pin-number sch-pin-label" x="366.66666666669005" y="300" style="font-family: sans-serif; text-decoration: overline;" fill="rgb(169, 0, 0)" text-anchor="start" dominant-baseline="middle" font-size="39.999999999996px" transform="">EN3</text><line class="component-pin sch-component-pin sch-port-line" x1="866.6666666666399" y1="233.33333333334" x2="993.3333333332939" y2="233.33333333334" stroke-width="6.666666666666px"/><g class="sch-port" data-schematic-port-id="src_port_1"><circle class="component-pin sch-component-pin sch-port-terminal" cx="999.99999999996" cy="233.33333333334" r="6.666666666666" stroke-width="6.666666666666px"/><rect x="993.333333333294" y="226.666666666674" width="13.333333333332" height="13.333333333332" opacity="0"/></g><text class="pin-number sch-pin-number" x="933.3333333333001" y="226.66666666667402" style="font-family: sans-serif;" fill="rgb(169, 0, 0)" text-anchor="middle" dominant-baseline="auto" font-size="49.999999999995px" transform=""></text><text class="pin-number sch-pin-label" x="833.33333333331" y="233.33333333334" style="font-family: sans-serif; text-decoration: overline;" fill="rgb(169, 0, 0)" text-anchor="end" dominant-baseline="middle" font-size="39.999999999996px" transform="">EN1</text><circle class="component-pin sch-component-pin sch-inversion-bubble" cx="886.6666666666379" cy="366.66666666666003" r="19.999999999998" fill="white" stroke="rgb(132, 0, 0)" stroke-width="6.666666666666px"/><line class="component-pin sch-component-pin sch-port-line" x1="906.6666666666359" y1="366.66666666666003" x2="993.3333333332939" y2="366.66666666666003" stroke-width="6.666666666666px"/><g class="sch-port" data-schematic-port-id="src_port_2"><circle class="component-pin sch-component-pin sch-port-terminal" cx="999.99999999996" cy="366.66666666666003" r="6.666666666666" stroke-width="6.666666666666px"/><rect x="993.333333333294" y="359.99999999999403" width="13.333333333332" height="13.333333333332" opacity="0"/></g><text class="pin-number sch-pin-number" x="933.3333333333001" y="359.99999999999403" style="font-family: sans-serif;" fill="rgb(169, 0, 0)" text-anchor="middle" dominant-baseline="auto" font-size="49.999999999995px" transform=""></text><text class="pin-number sch-pin-label" x="833.33333333331" y="366.66666666666003" style="font-family: sans-serif;" fill="rgb(169, 0, 0)" text-anchor="end" dominant-baseline="middle" font-size="39.999999999996px" transform="">EN2</text></g><g class="schematic-port-hover sch-port-hover" data-schematic-port-id="src_port_3"><circle cx="200.00000000004002" cy="300" r="13.333333333332" fill="red" opacity="0"/></g><g class="schematic-port-hover sch-port-hover" data-schematic-port-id="src_port_1"><circle cx="999.99999999996" cy="233.33333333334" r="13.333333333332" fill="red" opacity="0"/></g><g class="schematic-port-hover sch-port-hover" data-schematic-port-id="src_port_2"><circle cx="999.99999999996" cy="366.66666666666003" r="13.333333333332" fill="red" opacity="0"/></g></svg>

--- a/tests/sch/component-wrapper.test.tsx
+++ b/tests/sch/component-wrapper.test.tsx
@@ -88,6 +88,7 @@ test("component wrapper has correct attributes", () => {
   expect(svg).toContain('data-circuit-json-type="schematic_component"')
   expect(svg).toContain("data-schematic-component-id")
 
-  expect(svg).toContain('class="component-overlay"')
+  expect(svg).toContain("component-overlay")
+  expect(svg).toContain("sch-component-overlay")
   expect(svg).toContain('fill="transparent"')
 })

--- a/tests/sch/schematic-css-api.test.ts
+++ b/tests/sch/schematic-css-api.test.ts
@@ -1,0 +1,81 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToSchematicSvg } from "lib"
+
+test("schematic svg supports custom css and stable classes", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      source_component_id: "src_comp_1",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_port",
+      source_port_id: "src_port_1",
+      name: "EN1",
+      source_component_id: "src_comp_1",
+    },
+    {
+      type: "source_port",
+      source_port_id: "src_port_2",
+      name: "EN2",
+      source_component_id: "src_comp_1",
+    },
+    {
+      type: "source_port",
+      source_port_id: "src_port_3",
+      name: "EN3",
+      source_component_id: "src_comp_1",
+    },
+    {
+      type: "schematic_component",
+      schematic_component_id: "sch_comp_1",
+      source_component_id: "src_comp_1",
+      center: { x: 0, y: 0 },
+      size: { width: 1.6, height: 0.8 },
+      is_box_with_pins: true,
+    },
+    {
+      type: "schematic_port",
+      schematic_port_id: "sch_port_3",
+      schematic_component_id: "sch_comp_1",
+      source_port_id: "src_port_3",
+      center: { x: -1.2, y: 0 },
+      side_of_component: "left",
+      display_pin_label: "N_EN3",
+      is_drawn_with_inversion_circle: true,
+    },
+    {
+      type: "schematic_port",
+      schematic_port_id: "sch_port_1",
+      schematic_component_id: "sch_comp_1",
+      source_port_id: "src_port_1",
+      center: { x: 1.2, y: 0.2 },
+      side_of_component: "right",
+      display_pin_label: "N_EN1",
+    },
+    {
+      type: "schematic_port",
+      schematic_port_id: "sch_port_2",
+      schematic_component_id: "sch_comp_1",
+      source_port_id: "src_port_2",
+      center: { x: 1.2, y: -0.2 },
+      side_of_component: "right",
+      display_pin_label: "EN2",
+      is_drawn_with_inversion_circle: true,
+    },
+  ]
+
+  expect(
+    convertCircuitJsonToSchematicSvg(circuitJson, {
+      className: "custom-theme",
+      css: `
+        .custom-theme .sch-component-body {
+          fill: #c7d2fe !important;
+          stroke: #4338ca !important;
+        }
+      `,
+    }),
+  ).toMatchSvgSnapshot(import.meta.path)
+})


### PR DESCRIPTION
## Usage
```tsx
 convertCircuitJsonToSchematicSvg(circuitJson, {
    className: "custom-theme",
    css: `
      .custom-theme .sch-component-body {
        fill: #c7d2fe !important;
        stroke: #4338ca !important;
      }
    `,
  })
```

Use the `sch-*` classes for new styles. Some SVG elements also include older
generic classes for backwards compatibility, but the `sch-*` names are the
recommended public styling surface.

| Class | Target |
| --- | --- |
| `.tscircuit-schematic` | Root schematic SVG |
| `.sch-grid` | Schematic grid group |
| `.sch-labeled-points` | Debug/labeled point overlay group |
| `.sch-component` | Component wrapper group |
| `.sch-component-body` | Box-style component body |
| `.sch-component-overlay` | Transparent component hit target |
| `.sch-component-symbol-path` | Symbol path inside a component |
| `.sch-component-symbol-box` | Symbol box primitive inside a component |
| `.sch-component-symbol-circle` | Symbol circle primitive inside a component |
| `.sch-component-text` | Symbol text inside a component |
| `.sch-component-name` | Component reference/name text |
| `.sch-component-pin` | Component pin, terminal, and inversion-bubble geometry |
| `.sch-port` | Port wrapper group |
| `.sch-port-line` | Port line from component edge |
| `.sch-port-terminal` | Unconnected port terminal circle |
| `.sch-inversion-bubble` | Inversion bubble on a port |
| `.sch-port-indicator` | Port indicator when `drawPorts` is enabled |
| `.sch-port-label` | Port indicator label when `drawPorts` is enabled |
| `.sch-port-hover` | Transparent port hover/click target |
| `.sch-pin-number` | Pin number text |
| `.sch-pin-label` | Pin label text |
| `.sch-trace` | Trace base wrapper group |
| `.sch-trace-path` | Main trace stroke |
| `.sch-trace-hitbox` | Invisible wide trace hover stroke |
| `.sch-trace-overlays` | Trace overlay wrapper group |
| `.sch-trace-crossing-path` | Trace crossing/hop stroke |
| `.sch-trace-crossing-outline` | Background outline around crossing/hop stroke |
| `.sch-trace-junction` | Trace junction dot |
| `.sch-net-label` | Net label outline/body |
| `.sch-net-label-text` | Net label text |
| `.sch-net-label-overlay` | Transparent hit target for symbol net labels |
| `.sch-net-label-symbol-path` | Symbol path inside a net label |
| `.sch-net-label-symbol-text` | Symbol text inside a net label |
| `.sch-net-label-symbol-box` | Symbol box primitive inside a net label |
| `.sch-net-label-symbol-circle` | Symbol circle primitive inside a net label |
| `.sch-text` | Standalone schematic text |
| `.sch-box` | Schematic box |
| `.sch-table` | Schematic table wrapper group |
| `.sch-table-border` | Schematic table border |
| `.sch-table-grid-line` | Schematic table grid line |
| `.sch-table-text` | Schematic table cell text |
| `.sch-line` | Schematic line primitive |
| `.sch-circle` | Schematic circle primitive |
| `.sch-rect` | Schematic rectangle primitive |
| `.sch-arc` | Schematic arc primitive |
| `.sch-path` | Schematic path primitive |
| `.sch-voltage-probe` | Voltage probe arrow/path |
| `.sch-voltage-probe-label` | Voltage probe label |