### PR TITLE
chore: add package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,14 @@
   "type": "module",
   "version": "0.0.354",
   "description": "Convert Circuit JSON to SVG",
+  "homepage": "https://github.com/tscircuit/circuit-to-svg#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tscircuit/circuit-to-svg.git"
+  },
+  "bugs": {
+    "url": "https://github.com/tscircuit/circuit-to-svg/issues"
+  },
   "main": "dist/index.js",
   "files": [
     "dist"


### PR DESCRIPTION
## Summary

Adds npm package support metadata for `circuit-to-svg`:

- `homepage`
- `repository`
- `bugs.url`

This makes the published package metadata point users back to the public GitHub repository and issue tracker. Runtime code, build configuration, exports, dependencies, and package files are unchanged.

## Reproduction

Current published metadata does not expose those fields:

```sh
npm view circuit-to-svg@0.0.354 name version homepage repository bugs --json
```

Before this change, npm only returns the package name and version.

## Validation

```sh
npm pkg get name version homepage repository bugs --silent
npm pack --dry-run --ignore-scripts --json --silent
git diff --check
```

`npm pkg get` shows the expected metadata, `npm pack --dry-run` succeeds, and `git diff --check` reports no whitespace errors. The only local note was the usual Windows LF/CRLF working-copy warning.