### PR TITLE
fix(sch): resolve net-hover connectivity key from source_trace

### DIFF
--- a/lib/sch/convert-circuit-json-to-schematic-svg.ts
+++ b/lib/sch/convert-circuit-json-to-schematic-svg.ts
@@ -190,6 +190,17 @@ export function convertCircuitJsonToSchematicSvg(
   const schComponentSvgs: SvgObject[] = []
   const schTraceSvgs: SvgObject[] = []
   const connectivityKeys = new Set<string>()
+  // schematic_trace elements often don't carry a connectivity key themselves;
+  // fall back to the key on their source_trace so net hover works for them.
+  const sourceTraceConnectivityKeyById = new Map<string, string>()
+  for (const elm of circuitJson) {
+    if (elm.type === "source_trace" && elm.subcircuit_connectivity_map_key) {
+      sourceTraceConnectivityKeyById.set(
+        elm.source_trace_id,
+        elm.subcircuit_connectivity_map_key,
+      )
+    }
+  }
   const schNetLabel: SvgObject[] = []
   const schText: SvgObject[] = []
   const voltageProbeSvgs: SvgObject[] = []
@@ -250,14 +261,22 @@ export function convertCircuitJsonToSchematicSvg(
         }),
       )
     } else if (elm.type === "schematic_trace") {
+      const connectivityKey =
+        elm.subcircuit_connectivity_map_key ??
+        (elm.source_trace_id
+          ? sourceTraceConnectivityKeyById.get(elm.source_trace_id)
+          : undefined)
       schTraceSvgs.push(
         ...createSchematicTrace({
           trace: elm,
           transform,
           colorMap,
+          connectivityKey,
         }),
       )
-      connectivityKeys.add(elm.subcircuit_connectivity_map_key!)
+      if (connectivityKey) {
+        connectivityKeys.add(connectivityKey)
+      }
     } else if (elm.type === "schematic_net_label") {
       schNetLabel.push(
         ...createSvgObjectsForSchNetLabel({

--- a/lib/sch/svg-object-fns/create-svg-objects-from-sch-trace.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-from-sch-trace.ts
@@ -8,11 +8,15 @@ export function createSchematicTrace({
   trace,
   transform,
   colorMap,
+  connectivityKey,
 }: {
   trace: SchematicTrace
   transform: Matrix
   colorMap: ColorMap
+  connectivityKey?: string
 }): SvgObject[] {
+  const resolvedConnectivityKey =
+    connectivityKey ?? trace.subcircuit_connectivity_map_key
   const edges = trace.edges
   if (edges.length === 0) return []
   // Split into base vs overlay to control global z-order
@@ -183,9 +187,8 @@ export function createSchematicTrace({
         "data-layer": "base",
         "data-circuit-json-type": "schematic_trace",
         "data-schematic-trace-id": trace.schematic_trace_id,
-        ...(trace.subcircuit_connectivity_map_key && {
-          "data-subcircuit-connectivity-map-key":
-            trace.subcircuit_connectivity_map_key,
+        ...(resolvedConnectivityKey && {
+          "data-subcircuit-connectivity-map-key": resolvedConnectivityKey,
         }),
       },
       children: baseObjects,
@@ -199,9 +202,8 @@ export function createSchematicTrace({
         "data-layer": "overlay",
         "data-circuit-json-type": "schematic_trace",
         "data-schematic-trace-id": trace.schematic_trace_id,
-        ...(trace.subcircuit_connectivity_map_key && {
-          "data-subcircuit-connectivity-map-key":
-            trace.subcircuit_connectivity_map_key,
+        ...(resolvedConnectivityKey && {
+          "data-subcircuit-connectivity-map-key": resolvedConnectivityKey,
         }),
       },
       children: overlayObjects,

--- a/tests/sch/net-hover-connectivity-key-fallback.test.ts
+++ b/tests/sch/net-hover-connectivity-key-fallback.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToSchematicSvg } from "lib/index"
+
+const circuitJson: AnyCircuitElement[] = [
+  {
+    type: "source_trace",
+    source_trace_id: "source_trace_0",
+    connected_source_port_ids: [],
+    connected_source_net_ids: [],
+    subcircuit_connectivity_map_key: "unnamedsubcircuit0_connectivity_net5",
+  },
+  {
+    type: "source_trace",
+    source_trace_id: "source_trace_1",
+    connected_source_port_ids: [],
+    connected_source_net_ids: [],
+    subcircuit_connectivity_map_key: "unnamedsubcircuit0_connectivity_net5",
+  },
+  {
+    type: "schematic_trace",
+    schematic_trace_id: "schematic_trace_0",
+    source_trace_id: "source_trace_0",
+    edges: [{ from: { x: 0, y: 0 }, to: { x: 2, y: 0 } }],
+    junctions: [],
+  },
+  {
+    type: "schematic_trace",
+    schematic_trace_id: "schematic_trace_1",
+    source_trace_id: "source_trace_1",
+    edges: [{ from: { x: 0, y: 1 }, to: { x: 2, y: 1 } }],
+    junctions: [],
+  },
+] as AnyCircuitElement[]
+
+// schematic_trace elements usually only reference their source_trace and don't
+// carry subcircuit_connectivity_map_key themselves. Net hover styles target
+// [data-subcircuit-connectivity-map-key], so the key must be resolved from the
+// source_trace or hovering a trace won't highlight the rest of its net.
+// https://github.com/tscircuit/tscircuit/issues/1130
+test("net hover connectivity key falls back to source_trace", () => {
+  const svg = convertCircuitJsonToSchematicSvg(circuitJson)
+
+  // element attributes (not the [data-...] CSS selectors in the style block)
+  const attrMatches = svg.match(
+    /[^[]data-subcircuit-connectivity-map-key="unnamedsubcircuit0_connectivity_net5"/g,
+  )
+  // base + overlay group for each of the 2 traces
+  expect(attrMatches?.length).toBe(4)
+
+  // net hover CSS rules are emitted for the shared key
+  expect(svg).toContain(
+    'svg:has(:is(g.trace[data-subcircuit-connectivity-map-key="unnamedsubcircuit0_connectivity_net5"]',
+  )
+
+  // no bogus rules for traces without any resolvable key
+  expect(svg).not.toContain('data-subcircuit-connectivity-map-key="undefined"')
+})


### PR DESCRIPTION
## Problem

Hovering a schematic trace doesn't highlight the other traces on the same net (tscircuit/tscircuit#1130).

The net-hover CSS rules generated by `buildNetHoverStyles` target `[data-subcircuit-connectivity-map-key]` attributes, but `schematic_trace` elements usually only reference their `source_trace` and don't carry `subcircuit_connectivity_map_key` themselves — so the attribute was never stamped on the trace `<g>` groups and the selectors matched nothing. The connectivity key set also collected `undefined`, emitting a bogus `data-subcircuit-connectivity-map-key="undefined"` rule.

## Fix

- Resolve the connectivity key for each `schematic_trace` from its `source_trace` when the trace doesn't carry the key itself
- Only emit net-hover rules for defined keys

## Verification

- New regression test `tests/sch/net-hover-connectivity-key-fallback.test.ts`: two traces sharing a key via their source traces get the attribute stamped (base + overlay groups) and matching hover rules, with no `"undefined"` rules
- `bun test`: 230 pass / 0 fail
- `bunx tsc --noEmit`: clean

Fixes tscircuit/tscircuit#1130

/claim tscircuit/tscircuit#1130

🤖 Generated with [Claude Code](https://claude.com/claude-code)