### PR TITLE
Repro collapsed group port missing terminal dot

### DIFF
--- a/tests/sch/__snapshots__/collapsed-group-internal-port-terminal.snap.svg
+++ b/tests/sch/__snapshots__/collapsed-group-internal-port-terminal.snap.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="tscircuit-schematic" width="1200" height="600" style="background-color: rgb(245, 241, 237)" data-real-to-screen-transform="matrix(279.0697674419,0,0,-279.0697674419,669.7674418605,300)"><style>
+              .boundary { fill: rgb(245, 241, 237); }
+              .schematic-boundary { fill: none; stroke: #fff; }
+              .component { fill: none; stroke: rgb(132, 0, 0); }
+              .chip { fill: rgb(255, 255, 194); stroke: rgb(132, 0, 0); }
+              .component-pin { fill: none; stroke: rgb(132, 0, 0); }
+              .text { font-family: sans-serif; fill: rgb(0, 150, 0); }
+              .pin-number { fill: rgb(169, 0, 0); }
+              .port-label { fill: rgb(0, 100, 100); }
+              .component-name { fill: rgb(0, 100, 100); }
+              
+            </style><rect class="boundary" x="0" y="0" width="1200" height="600"/><g class="sch-component" data-circuit-json-type="schematic_component" data-schematic-component-id="collapsed_group"><rect class="component chip sch-component-body" x="279.06976744184" y="188.37209302323998" width="781.39534883732" height="223.25581395352003" stroke-width="5.581395348838px" fill="rgb(255, 255, 194)" stroke="rgb(132, 0, 0)"/><rect class="component-overlay sch-component-overlay" x="279.06976744184" y="188.37209302323998" width="781.39534883732" height="223.25581395352003" fill="transparent"/><line class="component-pin sch-component-pin sch-port-line" x1="279.06976744184" y1="300" x2="167.4418604650799" y2="300" stroke-width="5.581395348838px"/><g class="sch-port" data-schematic-port-id="public_port"><rect x="161.86046511624193" y="294.418604651162" width="11.162790697676" height="11.162790697676" opacity="0"/></g><text class="pin-number sch-pin-number" x="223.2558139534599" y="294.418604651162" style="font-family: sans-serif;" fill="rgb(169, 0, 0)" text-anchor="middle" dominant-baseline="auto" font-size="41.860465116285px" transform=""></text><text class="pin-number sch-pin-label" x="306.9767441860299" y="300" style="font-family: sans-serif;" fill="rgb(169, 0, 0)" text-anchor="start" dominant-baseline="middle" font-size="41.860465116285px" transform="">ROW1</text></g><g class="schematic-port-hover sch-port-hover" data-schematic-port-id="public_port"><circle cx="167.4418604650799" cy="300" r="11.162790697676" fill="red" opacity="0"/></g></svg>

--- a/tests/sch/collapsed-group-internal-port-terminal.test.ts
+++ b/tests/sch/collapsed-group-internal-port-terminal.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToSchematicSvg } from "lib"
+
+test("collapsed group public ports use schematic connection state", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_port",
+      source_port_id: "public_port",
+      name: "ROW1",
+    },
+    {
+      type: "source_component",
+      source_component_id: "internal_led",
+      name: "D1",
+      ftype: "simple_led",
+    },
+    {
+      type: "source_port",
+      source_port_id: "internal_port",
+      name: "anode",
+      source_component_id: "internal_led",
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "internal_trace",
+      connected_source_port_ids: ["public_port", "internal_port"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "schematic_component",
+      schematic_component_id: "collapsed_group",
+      source_component_id: "source_group_0",
+      center: { x: 0, y: 0 },
+      size: { width: 2.8, height: 0.8 },
+      is_box_with_pins: true,
+    },
+    {
+      type: "schematic_port",
+      schematic_port_id: "public_schematic_port",
+      schematic_component_id: "collapsed_group",
+      source_port_id: "public_port",
+      center: { x: -1.8, y: 0 },
+      facing_direction: "left",
+      side_of_component: "left",
+      distance_from_component_edge: 0.4,
+      display_pin_label: "ROW1",
+      is_connected: false,
+    },
+  ]
+
+  const svg = convertCircuitJsonToSchematicSvg(circuitJson)
+
+  expect(svg.match(/sch-port-terminal/g) ?? []).toHaveLength(0)
+  expect(svg).toMatchSvgSnapshot(import.meta.path)
+})


### PR DESCRIPTION
## Summary

- adds a type-valid raw Circuit JSON reproduction matching the core case
- keeps the single public `ROW1` port source-connected to a hidden internal implementation pin
- records the current bug: `ROW1` renders without a terminal dot even though it is schematically unconnected
- adds the broken-state schematic SVG snapshot

## Verification

- `bun test tests/sch/collapsed-group-internal-port-terminal.test.ts`
- `bun test` (263 pass, 0 fail)
- `bunx tsc --noEmit`
- `bun run format:check`

This is PR 1 of 2 in a stack. The follow-up fix is #621.
