### PR TITLE
fix: keep non-finite hole radii out of the SVG (#634)

### DIFF
--- a/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-plated-hole.ts
+++ b/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-plated-hole.ts
@@ -274,8 +274,15 @@ export function createSvgObjectsFromPcbPlatedHole(
     const scaledHoleWidth = hole.hole_diameter * Math.abs(transform.a)
     const scaledHoleHeight = hole.hole_diameter * Math.abs(transform.a)
 
-    const outerRadius = Math.min(scaledOuterWidth, scaledOuterHeight) / 2
-    const innerRadius = Math.min(scaledHoleWidth, scaledHoleHeight) / 2
+    const rawOuterRadius = Math.min(scaledOuterWidth, scaledOuterHeight) / 2
+    const rawInnerRadius = Math.min(scaledHoleWidth, scaledHoleHeight) / 2
+
+    // A missing or unparseable diameter reaches here as null/NaN, which would be
+    // written as r="NaN" — not a valid SVG length, so renderers drop the circle
+    // and the drill silently vanishes. Clamp at the source so everything derived
+    // from these radii (soldermask mask radius included) stays a valid length.
+    const outerRadius = Number.isFinite(rawOuterRadius) ? rawOuterRadius : 0
+    const innerRadius = Number.isFinite(rawInnerRadius) ? rawInnerRadius : 0
 
     let children: SvgObject[] = [
       {

--- a/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-via.ts
+++ b/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-via.ts
@@ -10,8 +10,16 @@ export function createSvgObjectsFromPcbVia(hole: PCBVia, ctx: PcbContext): any {
   const scaledHoleWidth = hole.hole_diameter * Math.abs(transform.a)
   const scaledHoleHeight = hole.hole_diameter * Math.abs(transform.a)
 
-  const outerRadius = Math.min(scaledOuterWidth, scaledOuterHeight) / 2
-  const innerRadius = Math.min(scaledHoleWidth, scaledHoleHeight) / 2
+  const rawOuterRadius = Math.min(scaledOuterWidth, scaledOuterHeight) / 2
+  const rawInnerRadius = Math.min(scaledHoleWidth, scaledHoleHeight) / 2
+
+  // A missing or unparseable diameter arrives here as null/NaN and would be
+  // written as r="NaN", which is not a valid SVG length — renderers drop the
+  // circle entirely, so the drill silently disappears instead of looking wrong.
+  // Fall back to 0 so the attribute stays a valid length.
+  const outerRadius = Number.isFinite(rawOuterRadius) ? rawOuterRadius : 0
+  const innerRadius = Number.isFinite(rawInnerRadius) ? rawInnerRadius : 0
+
   return {
     name: "g",
     type: "element",

--- a/tests/pcb/non-finite-hole-radius.test.ts
+++ b/tests/pcb/non-finite-hole-radius.test.ts
@@ -1,0 +1,105 @@
+import { expect, test } from "bun:test"
+import { convertCircuitJsonToPcbSvg } from "lib"
+
+const board = {
+  type: "pcb_board",
+  pcb_board_id: "board0",
+  center: { x: 0, y: 0 },
+  width: 20,
+  height: 20,
+}
+
+const radiiIn = (svg: string, dataType: string) => {
+  const group = svg.match(
+    new RegExp(`<g data-type="${dataType}"[\\s\\S]*?</g>`),
+  )?.[0]
+  return [...(group ?? "").matchAll(/ r="([^"]*)"/g)].map((m) => m[1])
+}
+
+test('a via with a NaN hole_diameter does not emit r="NaN"', () => {
+  // An unparseable unit string (e.g. holeDiameter="abc") reaches the renderer
+  // as NaN — see the values tscircuit emits before JSON serialisation.
+  const svg = convertCircuitJsonToPcbSvg([
+    board,
+    {
+      type: "pcb_via",
+      pcb_via_id: "via0",
+      x: 5,
+      y: 5,
+      outer_diameter: 0.6,
+      hole_diameter: Number.NaN,
+      layers: ["top", "bottom"],
+    },
+  ] as any)
+
+  expect(svg).not.toContain('r="NaN"')
+  // The valid outer diameter is preserved; only the unusable drill falls back.
+  const radii = radiiIn(svg, "pcb_via")
+  expect(radii).toHaveLength(2)
+  expect(Number(radii[0])).toBeGreaterThan(0)
+  expect(radii[1]).toBe("0")
+})
+
+test('a plated hole with a NaN hole_diameter does not emit r="NaN"', () => {
+  const svg = convertCircuitJsonToPcbSvg([
+    board,
+    {
+      type: "pcb_plated_hole",
+      pcb_plated_hole_id: "ph0",
+      shape: "circle",
+      x: 5,
+      y: 5,
+      outer_diameter: 1,
+      hole_diameter: Number.NaN,
+      layers: ["top", "bottom"],
+    },
+  ] as any)
+
+  expect(svg).not.toContain('r="NaN"')
+})
+
+test("valid via dimensions are still rendered verbatim", () => {
+  // Guards against clamping everything to 0.
+  const svg = convertCircuitJsonToPcbSvg([
+    board,
+    {
+      type: "pcb_via",
+      pcb_via_id: "via0",
+      x: 5,
+      y: 5,
+      outer_diameter: 0.6,
+      hole_diameter: 0.3,
+      layers: ["top", "bottom"],
+    },
+  ] as any)
+
+  expect(svg).not.toContain('r="NaN"')
+
+  const radii = radiiIn(svg, "pcb_via").map(Number)
+  expect(radii).toHaveLength(2)
+  expect(radii[0]).toBeGreaterThan(0)
+  expect(radii[1]).toBeGreaterThan(0)
+  // outer_diameter is twice hole_diameter, so the radii must keep that ratio.
+  expect(radii[0]! / radii[1]!).toBeCloseTo(2, 6)
+})
+
+test("valid plated hole dimensions are still rendered verbatim", () => {
+  const svg = convertCircuitJsonToPcbSvg([
+    board,
+    {
+      type: "pcb_plated_hole",
+      pcb_plated_hole_id: "ph0",
+      shape: "circle",
+      x: 5,
+      y: 5,
+      outer_diameter: 1,
+      hole_diameter: 0.5,
+      layers: ["top", "bottom"],
+    },
+  ] as any)
+
+  expect(svg).not.toContain('r="NaN"')
+
+  const radii = radiiIn(svg, "pcb_plated_hole").map(Number)
+  expect(radii.every((r) => Number.isFinite(r) && r > 0)).toBe(true)
+})


### PR DESCRIPTION
Fixes #634.

### What was wrong

A via or plated hole with a non-finite diameter emitted `r="NaN"`:

```html
<circle class="pcb-hole-inner" fill="#FF26E2" cx="536.36" cy="163.63" r="NaN"
        data-type="pcb_via" data-pcb-layer="drill"/>
```

`NaN` isn't a valid SVG length, so renderers discard the `<circle>` entirely — the drill **vanishes silently**. The rest of the board still draws, which makes it worse: you get a plausible-looking PCB with a via that has no hole, and nothing says why.

Both sites multiplied the diameter into a radius and stringified it, and `NaN * n` stays `NaN`.

### A repro note that cost me time — please read before testing

**The value is `NaN` in memory but becomes `null` after JSON serialisation**, and `null * n` is `0`, which renders harmlessly.

So a test built from a hand-written JSON literal with `hole_diameter: null` **passes even without this fix** — I hit exactly that and my first version of these tests was worthless. The bug only appears on the in-memory path `tscircuit` produces, which is the path the converter is normally called on. The tests here use `Number.NaN` for that reason, and I verified they fail without the fix.

### The fix

Clamp at the source in both files:

```ts
const outerRadius = Number.isFinite(rawOuterRadius) ? rawOuterRadius : 0
const innerRadius = Number.isFinite(rawInnerRadius) ? rawInnerRadius : 0
```

Clamping the radius variables themselves (rather than each `.toString()` call site) matters for plated holes, where `maskRadius = outerRadius + soldermaskMargin` feeds two more soldermask circles — those are covered without touching them.

`Number.isFinite` also catches `Infinity`, and follows the pattern already in `lib/sim/simulation-graph-svg/format-value-with-unit.ts` (`if (!Number.isFinite(value)) return "0"`), so this isn't a new convention.

### Scope

Only the two circular-radius paths with a demonstrated failure. I didn't sweep every numeric attribute in the PCB renderer — that's a much larger change, and I'd rather land the proven one first. Happy to follow up if you want the broader pass.

### Tests

`tests/pcb/non-finite-hole-radius.test.ts`, four tests pinning both directions:

| case | expected |
|---|---|
| via, `hole_diameter: NaN` | no `r="NaN"`; outer radius still **> 0**, inner falls back to `0` |
| plated hole, `hole_diameter: NaN` | no `r="NaN"` |
| via, valid `0.6` / `0.3` | both radii > 0 **and their ratio is 2**, matching the diameters |
| plated hole, valid `1` / `0.5` | all radii finite and > 0 |

The ratio assertion is the guard rail: a fix that clamped everything to `0` would pass a bare "no NaN" check but fails this. The first case checks the same thing at finer grain — the valid outer diameter survives while only the unusable drill falls back.

Bite-proofed: reverting `lib/pcb/` takes the file from **4 pass** to **2 pass / 2 fail**.

### Verification

`bun test`: **295 pass / 0 fail** (baseline on `main` is 291 pass / 0 fail; +4 new). No snapshot churn. `bunx tsc --noEmit` clean, `bun run format:check` clean.
