### PR TITLE
fix: keep non-finite font sizes and keepout radii out of the SVG (#636)

### DIFF
--- a/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-keepout.ts
+++ b/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-keepout.ts
@@ -186,7 +186,13 @@ export function createSvgObjectsFromPcbKeepout(
         circleKeepout.center.x,
         circleKeepout.center.y,
       ])
-      const scaledRadius = circleKeepout.radius * Math.abs(transform.a)
+      const rawScaledRadius = circleKeepout.radius * Math.abs(transform.a)
+      // A missing or unparseable radius reaches here as null/NaN and would be
+      // written as r="NaN", which is not a valid SVG length — renderers discard
+      // the circle, so the keepout silently disappears from the drawing.
+      const scaledRadius = Number.isFinite(rawScaledRadius)
+        ? rawScaledRadius
+        : 0
 
       const backgroundAttributes = {
         ...createKeepoutBaseAttributes(

--- a/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-silkscreen-text.ts
+++ b/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-silkscreen-text.ts
@@ -229,7 +229,14 @@ export function createSvgObjectsFromPcbSilkscreenText(
     ]
   }
 
-  const transformedFontSize = font_size * scaleFactor
+  // A default parameter only covers `undefined`; an unparseable size arrives as
+  // NaN and would be written as font-size="NaN", which is not a valid SVG length
+  // — renderers fall back to their own default or drop the text, so the label
+  // silently changes size or disappears.
+  const rawTransformedFontSize = font_size * scaleFactor
+  const transformedFontSize = Number.isFinite(rawTransformedFontSize)
+    ? rawTransformedFontSize
+    : scaleFactor
 
   let textAnchor = "middle"
   let dominantBaseline = "central"

--- a/tests/pcb/non-finite-silkscreen-and-keepout.test.ts
+++ b/tests/pcb/non-finite-silkscreen-and-keepout.test.ts
@@ -1,0 +1,110 @@
+import { expect, test } from "bun:test"
+import { convertCircuitJsonToPcbSvg } from "lib"
+
+const board = {
+  type: "pcb_board",
+  pcb_board_id: "board0",
+  center: { x: 0, y: 0 },
+  width: 20,
+  height: 20,
+}
+
+const fontSizesIn = (svg: string) => [
+  ...new Set([...svg.matchAll(/font-size="([^"]+)"/g)].map((m) => m[1])),
+]
+
+const keepoutRadiiIn = (svg: string) => [
+  ...new Set(
+    [...svg.matchAll(/pcb-keepout-circle[^>]*? r="([^"]+)"/g)].map((m) => m[1]),
+  ),
+]
+
+// NOTE: these use Number.NaN rather than null on purpose. An unparseable unit
+// string reaches the renderer as NaN in memory; it only becomes null after JSON
+// serialisation, and null * n === 0 renders harmlessly. A null-based fixture
+// would pass even without the fix.
+
+test('a silkscreen text with a non-finite font_size does not emit font-size="NaN"', () => {
+  const svg = convertCircuitJsonToPcbSvg([
+    board,
+    {
+      type: "pcb_silkscreen_text",
+      pcb_silkscreen_text_id: "text0",
+      anchor_position: { x: 3, y: 3 },
+      anchor_alignment: "center",
+      font: "tscircuit2024",
+      font_size: Number.NaN,
+      layer: "top",
+      text: "hi",
+    },
+  ] as any)
+
+  expect(svg).not.toContain('font-size="NaN"')
+  expect(fontSizesIn(svg).every((s) => Number.isFinite(Number(s)))).toBe(true)
+})
+
+test("a valid font_size is still scaled verbatim", () => {
+  // Guards against clamping every label to the fallback size.
+  const withSize = (font_size: number) =>
+    convertCircuitJsonToPcbSvg([
+      board,
+      {
+        type: "pcb_silkscreen_text",
+        pcb_silkscreen_text_id: "text0",
+        anchor_position: { x: 3, y: 3 },
+        anchor_alignment: "center",
+        font: "tscircuit2024",
+        font_size,
+        layer: "top",
+        text: "hi",
+      },
+    ] as any)
+
+  const one = Number(fontSizesIn(withSize(1))[0])
+  const twice = Number(fontSizesIn(withSize(2))[0])
+
+  expect(Number.isFinite(one)).toBe(true)
+  // Doubling font_size must double the rendered size — a clamped fix would not.
+  expect(twice / one).toBeCloseTo(2, 6)
+})
+
+test('a circular keepout with a non-finite radius does not emit r="NaN"', () => {
+  const svg = convertCircuitJsonToPcbSvg([
+    board,
+    {
+      type: "pcb_keepout",
+      pcb_keepout_id: "keepout0",
+      shape: "circle",
+      center: { x: 5, y: 5 },
+      radius: Number.NaN,
+      layers: ["top"],
+    },
+  ] as any)
+
+  expect(svg).not.toContain('r="NaN"')
+})
+
+test("a valid keepout radius is still rendered verbatim", () => {
+  const radiusFor = (radius: number) =>
+    Number(
+      keepoutRadiiIn(
+        convertCircuitJsonToPcbSvg([
+          board,
+          {
+            type: "pcb_keepout",
+            pcb_keepout_id: "keepout0",
+            shape: "circle",
+            center: { x: 5, y: 5 },
+            radius,
+            layers: ["top"],
+          },
+        ] as any),
+      )[0],
+    )
+
+  const small = radiusFor(1)
+  const large = radiusFor(2)
+
+  expect(small).toBeGreaterThan(0)
+  expect(large / small).toBeCloseTo(2, 6)
+})


### PR DESCRIPTION
Fixes #636. Same class as #634, found by sweeping the remaining numeric attributes in the PCB renderer. **Independent of #635** — different files, no conflict, either order.

### What was wrong

Two more non-finite values reaching SVG attributes:

```html
<text ... font-size="NaN" ...>                        <!-- silkscreen text -->
<circle class="pcb-keepout-circle" ... r="NaN" .../>  <!-- circular keepout -->
```

Neither is a valid SVG length. The text falls back to the renderer's own default size or disappears; the keepout circle is discarded outright. Both leave a drawing that looks fine while showing something other than what was specified.

**Silkscreen text is the interesting one.** It already had what looks like a guard:

```ts
const { font_size = 1, ... } = pcbSilkscreenText
const transformedFontSize = font_size * scaleFactor
```

A default parameter only fires on `undefined`. `NaN` sails past it, and `NaN * scaleFactor` stays `NaN` — the same shape as `??` not catching `NaN`.

**Keepout** had no guard at all.

### Repro note — worth knowing before testing

The value is **`NaN` in memory but `null` after JSON serialisation**, and `null * n === 0`, which renders harmlessly. A fixture written as a JSON literal with `null` **passes without the fix**. These tests use `Number.NaN` for that reason, and I confirmed they fail when the change is reverted.

### The fix

- **Silkscreen:** fall back to `scaleFactor`, which is exactly what the existing `font_size = 1` default produces — so a broken size renders at the same size the code already treats as its default, rather than at an arbitrary number.
- **Keepout:** fall back to `0`, matching how #635 handles an unusable radius.

Both use `Number.isFinite` (also catching `Infinity`), consistent with `lib/sim/simulation-graph-svg/format-value-with-unit.ts`. Clamping `scaledRadius` at the variable covers both `r:` sites in the keepout path.

### Tests

`tests/pcb/non-finite-silkscreen-and-keepout.test.ts`, four tests:

| case | expected |
|---|---|
| `font_size: NaN` | no `font-size="NaN"`; every emitted font-size is finite |
| `font_size` 1 vs 2 | rendered size **doubles** — proves scaling is untouched |
| keepout `radius: NaN` | no `r="NaN"` |
| keepout radius 1 vs 2 | rendered radius **doubles**, and is > 0 |

The two ratio tests are the guard rails: a fix that clamped everything to a constant would pass a bare "no NaN" check but fails these. I asserted ratios rather than hardcoded pixel values so the tests don't break on unrelated transform changes.

Bite-proofed: reverting `lib/pcb/` takes the file from **4 pass** to **2 pass / 2 fail**.

### Verification

`bun test`: **295 pass / 0 fail** (291 on `main`; +4 new). No snapshot churn. `bunx tsc --noEmit` clean, `bun run format:check` clean.
