### PR TITLE
fix: keep non-finite schematic component sizes out of the SVG (#638)

### DIFF
--- a/lib/sch/svg-object-fns/create-svg-objects-from-sch-component-with-box.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-from-sch-component-with-box.ts
@@ -29,13 +29,25 @@ export const createSvgObjectsFromSchematicComponentWithBox = ({
 }): SvgObject[] => {
   const svgObjects: SvgObject[] = []
 
+  // A missing or unparseable schematic dimension arrives as null/NaN. Every
+  // coordinate below is derived from these two numbers, so letting one through
+  // turns the body rect, the pin lines and the labels into x="NaN" — none of
+  // which is a valid SVG length, so the whole component vanishes from the
+  // drawing. Fall back to 0 so the geometry stays well-formed.
+  const componentWidth = Number.isFinite(schComponent.size.width)
+    ? schComponent.size.width
+    : 0
+  const componentHeight = Number.isFinite(schComponent.size.height)
+    ? schComponent.size.height
+    : 0
+
   const componentScreenTopLeft = applyToPoint(transform, {
-    x: schComponent.center.x - schComponent.size.width / 2,
-    y: schComponent.center.y + schComponent.size.height / 2,
+    x: schComponent.center.x - componentWidth / 2,
+    y: schComponent.center.y + componentHeight / 2,
   })
   const componentScreenBottomRight = applyToPoint(transform, {
-    x: schComponent.center.x + schComponent.size.width / 2,
-    y: schComponent.center.y - schComponent.size.height / 2,
+    x: schComponent.center.x + componentWidth / 2,
+    y: schComponent.center.y - componentHeight / 2,
   })
   const componentScreenWidth =
     componentScreenBottomRight.x - componentScreenTopLeft.x

--- a/tests/sch/non-finite-component-size.test.ts
+++ b/tests/sch/non-finite-component-size.test.ts
@@ -1,0 +1,79 @@
+import { expect, test } from "bun:test"
+import { convertCircuitJsonToSchematicSvg } from "lib"
+
+// NOTE: these use Number.NaN rather than null on purpose. An unparseable
+// dimension reaches the renderer as NaN in memory; it only becomes null once the
+// circuit JSON is serialised, and `null / 2` is 0, which renders harmlessly.
+// A null-based fixture would pass even without the fix.
+
+const circuitWithSize = (size: { width: number; height: number }): any => [
+  {
+    type: "schematic_component",
+    schematic_component_id: "sc1",
+    center: { x: 0, y: 0 },
+    rotation: 0,
+    size,
+    pin_spacing: 0.2,
+    port_labels: {},
+    source_component_id: "src1",
+  },
+  {
+    type: "source_component",
+    source_component_id: "src1",
+    ftype: "simple_chip",
+    name: "U1",
+  },
+  {
+    type: "schematic_port",
+    schematic_port_id: "sp1",
+    schematic_component_id: "sc1",
+    center: { x: 0.5, y: 0.3 },
+    source_port_id: "p1",
+    facing_direction: "right",
+    distance_from_component_edge: 0.4,
+    pin_number: 1,
+  },
+]
+
+test("a non-finite component width does not put NaN in the schematic", () => {
+  const svg = convertCircuitJsonToSchematicSvg(
+    circuitWithSize({ width: Number.NaN, height: 1 }),
+  )
+
+  expect(svg).not.toContain("NaN")
+})
+
+test("a non-finite component height does not put NaN in the schematic", () => {
+  const svg = convertCircuitJsonToSchematicSvg(
+    circuitWithSize({ width: 1, height: Number.NaN }),
+  )
+
+  expect(svg).not.toContain("NaN")
+})
+
+test("the component body is still drawn at the right size for valid input", () => {
+  // Guards against clamping every component to zero.
+  const widthFor = (width: number) => {
+    const svg = convertCircuitJsonToSchematicSvg(
+      circuitWithSize({ width, height: 1 }),
+    )
+    const body =
+      svg.match(/class="component chip sch-component-body"[^>]*/)?.[0] ?? ""
+    return Number(body.match(/ width="([^"]+)"/)?.[1])
+  }
+
+  const single = widthFor(1)
+  const double = widthFor(2)
+
+  expect(single).toBeGreaterThan(0)
+  // Doubling the component width must double the rendered body width.
+  expect(double / single).toBeCloseTo(2, 6)
+})
+
+test("valid components render without NaN", () => {
+  const svg = convertCircuitJsonToSchematicSvg(
+    circuitWithSize({ width: 2, height: 1 }),
+  )
+
+  expect(svg).not.toContain("NaN")
+})


### PR DESCRIPTION
Fixes #638. Third in the same sweep as #635 and #637 — **independent of both** (different file, no conflict, any order).

### What was wrong

A schematic component with a non-finite `size` rendered **112 `NaN`s** for a single chip:

```html
<rect class="component chip sch-component-body" x="NaN" y="NaN" width="NaN" height="NaN" ...>
```

They spread across `x`, `y`, `width`, `height`, `transform`, `x1`, `y1`, `x2`, `y2`, `cx`, `cy` — body rect, pin lines and labels. None is a valid SVG length, so renderers discard those elements and the component is simply **absent** from the sheet. Everything else still draws, so it reads as a layout problem rather than a bad prop.

Every screen coordinate is derived from the two size numbers, and `NaN / 2` stays `NaN`:

```ts
x: schComponent.center.x - schComponent.size.width / 2,
```

### Repro note — worth knowing before testing

The value is **`NaN` in memory but `null` after JSON serialisation**, and `null / 2 === 0`, which renders harmlessly. A fixture written as a JSON literal with `null` **passes without the fix**. The tests here use `Number.NaN` for that reason, and I confirmed they fail when the change is reverted.

### The fix

Clamp both dimensions once, at the top, before any coordinate is derived:

```ts
const componentWidth = Number.isFinite(schComponent.size.width) ? schComponent.size.width : 0
const componentHeight = Number.isFinite(schComponent.size.height) ? schComponent.size.height : 0
```

Doing it at the source rather than per-attribute is what makes the body, the overlay and the derived positions all come out well-formed from one guard. `Number.isFinite` also catches `Infinity`, matching #635/#637 and the existing pattern in `lib/sim/simulation-graph-svg/format-value-with-unit.ts`.

### Scope — stated honestly

This does not get a real `tscircuit` circuit all the way to zero `NaN`s, and I don't want to imply otherwise. With `schWidth="abc"`, core also emits `schematic_port.center` as `{x: null, y: null}` for that component; a renderer can't invent port coordinates, so those remain.

What this fixes is measurable in isolation: give the ports real coordinates and leave the size non-finite, and the output goes from **8 `NaN`s to 0**. That's the case the tests pin.

The upstream half is separate and already filed — tscircuit/core#2861 (negative schematic dimensions) and tscircuit/core#2855 (unparseable unit values raising nothing).

### Tests

`tests/sch/non-finite-component-size.test.ts`, four tests:

| case | expected |
|---|---|
| `size.width: NaN` | no `NaN` anywhere in the output |
| `size.height: NaN` | no `NaN` anywhere in the output |
| width 1 vs 2 | rendered body width **doubles** |
| valid 2x1 component | no `NaN` |

The ratio test is the guard rail — a fix that clamped every component to zero would pass a bare "no NaN" check but fails this. I asserted a ratio rather than a pixel constant so it doesn't break on unrelated transform changes.

Bite-proofed: reverting `lib/sch/` takes the file from **4 pass** to **2 pass / 2 fail**.

### Verification

`bun test`: **295 pass / 0 fail** (291 on `main`; +4 new). No snapshot churn. `bunx tsc --noEmit` clean, `bun run format:check` clean.
