### PR TITLE
fix: keep negative lengths out of the SVG (#640)

### DIFF
--- a/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-hole.ts
+++ b/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-hole.ts
@@ -2,6 +2,7 @@ import type { PCBHole } from "circuit-json"
 import { applyToPoint } from "transformation-matrix"
 import type { SvgObject } from "lib/svg-object"
 import type { PcbContext } from "../convert-circuit-json-to-pcb-svg"
+import { toSvgLength } from "lib/utils/to-svg-length"
 
 export function createSvgObjectsFromPcbHole(
   hole: PCBHole,
@@ -26,7 +27,7 @@ export function createSvgObjectsFromPcbHole(
 
   if (hole.hole_shape === "circle" || hole.hole_shape === "square") {
     const scaledDiameter = hole.hole_diameter * Math.abs(transform.a)
-    const radius = scaledDiameter / 2
+    const radius = toSvgLength(scaledDiameter / 2)
 
     if (hole.hole_shape === "circle") {
       const holeElement: SvgObject = {
@@ -375,7 +376,7 @@ export function createSvgObjectsFromPcbHole(
     // Pill shape: two semicircles connected by straight lines
     // If width > height, it's a horizontal pill; if height > width, it's vertical
     const isHorizontal = scaledWidth > scaledHeight
-    const radius = Math.min(scaledWidth, scaledHeight) / 2
+    const radius = toSvgLength(Math.min(scaledWidth, scaledHeight) / 2)
     const straightLength = Math.abs(
       isHorizontal ? scaledWidth - scaledHeight : scaledHeight - scaledWidth,
     )
@@ -494,7 +495,7 @@ export function createSvgObjectsFromPcbHole(
 
     // Same logic as regular pill: handle horizontal and vertical orientations
     const isHorizontal = scaledWidth > scaledHeight
-    const radius = Math.min(scaledWidth, scaledHeight) / 2
+    const radius = toSvgLength(Math.min(scaledWidth, scaledHeight) / 2)
     const straightLength = Math.abs(
       isHorizontal ? scaledWidth - scaledHeight : scaledHeight - scaledWidth,
     )

--- a/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-keepout.ts
+++ b/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-keepout.ts
@@ -7,6 +7,7 @@ import {
   toString as matrixToString,
 } from "transformation-matrix"
 import type { PcbContext } from "../convert-circuit-json-to-pcb-svg"
+import { toSvgLength } from "lib/utils/to-svg-length"
 
 const KEEPOUT_PATTERN_ID = "pcb-keepout-pattern"
 const KEEPOUT_PATTERN_SIZE = 20
@@ -186,7 +187,9 @@ export function createSvgObjectsFromPcbKeepout(
         circleKeepout.center.x,
         circleKeepout.center.y,
       ])
-      const scaledRadius = circleKeepout.radius * Math.abs(transform.a)
+      const scaledRadius = toSvgLength(
+        circleKeepout.radius * Math.abs(transform.a),
+      )
 
       const backgroundAttributes = {
         ...createKeepoutBaseAttributes(

--- a/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-plated-hole.ts
+++ b/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-plated-hole.ts
@@ -8,6 +8,7 @@ import { applyToPoint } from "transformation-matrix"
 import type { SvgObject } from "lib/svg-object"
 import type { PcbContext } from "../convert-circuit-json-to-pcb-svg"
 import { getPadDataAttributes } from "./get-pad-data-attributes"
+import { toSvgLength } from "lib/utils/to-svg-length"
 
 type HoleWithRectPadOffsets = {
   hole_offset_x?: number
@@ -274,8 +275,14 @@ export function createSvgObjectsFromPcbPlatedHole(
     const scaledHoleWidth = hole.hole_diameter * Math.abs(transform.a)
     const scaledHoleHeight = hole.hole_diameter * Math.abs(transform.a)
 
-    const outerRadius = Math.min(scaledOuterWidth, scaledOuterHeight) / 2
-    const innerRadius = Math.min(scaledHoleWidth, scaledHoleHeight) / 2
+    // Clamped at the source so everything derived from these radii (the
+    // soldermask mask radius included) stays a valid SVG length.
+    const outerRadius = toSvgLength(
+      Math.min(scaledOuterWidth, scaledOuterHeight) / 2,
+    )
+    const innerRadius = toSvgLength(
+      Math.min(scaledHoleWidth, scaledHoleHeight) / 2,
+    )
 
     let children: SvgObject[] = [
       {

--- a/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-via.ts
+++ b/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-via.ts
@@ -1,6 +1,7 @@
 import type { PCBVia } from "circuit-json"
 import { applyToPoint } from "transformation-matrix"
 import type { PcbContext } from "../convert-circuit-json-to-pcb-svg"
+import { toSvgLength } from "lib/utils/to-svg-length"
 
 export function createSvgObjectsFromPcbVia(hole: PCBVia, ctx: PcbContext): any {
   const { transform, colorMap } = ctx
@@ -10,8 +11,12 @@ export function createSvgObjectsFromPcbVia(hole: PCBVia, ctx: PcbContext): any {
   const scaledHoleWidth = hole.hole_diameter * Math.abs(transform.a)
   const scaledHoleHeight = hole.hole_diameter * Math.abs(transform.a)
 
-  const outerRadius = Math.min(scaledOuterWidth, scaledOuterHeight) / 2
-  const innerRadius = Math.min(scaledHoleWidth, scaledHoleHeight) / 2
+  const outerRadius = toSvgLength(
+    Math.min(scaledOuterWidth, scaledOuterHeight) / 2,
+  )
+  const innerRadius = toSvgLength(
+    Math.min(scaledHoleWidth, scaledHoleHeight) / 2,
+  )
   return {
     name: "g",
     type: "element",

--- a/lib/sch/svg-object-fns/create-svg-objects-from-sch-component-with-box.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-from-sch-component-with-box.ts
@@ -15,6 +15,7 @@ import { createSvgObjectsFromSchPortOnBox } from "./create-svg-objects-from-sch-
 import { getSchStrokeSize } from "lib/utils/get-sch-stroke-size"
 import { getSchScreenFontSize } from "lib/utils/get-sch-font-size"
 import { createSvgSchText } from "./create-svg-objects-for-sch-text"
+import { toSvgLength } from "lib/utils/to-svg-length"
 
 export const createSvgObjectsFromSchematicComponentWithBox = ({
   component: schComponent,
@@ -29,13 +30,20 @@ export const createSvgObjectsFromSchematicComponentWithBox = ({
 }): SvgObject[] => {
   const svgObjects: SvgObject[] = []
 
+  // A negative schematic dimension flips the corners, so the derived width and
+  // height come out negative — and a negative `width`/`height` is an error per
+  // the SVG spec, so the body rect is simply not drawn. Clamp at the source so
+  // every coordinate derived below stays well-formed.
+  const componentWidth = toSvgLength(schComponent.size.width)
+  const componentHeight = toSvgLength(schComponent.size.height)
+
   const componentScreenTopLeft = applyToPoint(transform, {
-    x: schComponent.center.x - schComponent.size.width / 2,
-    y: schComponent.center.y + schComponent.size.height / 2,
+    x: schComponent.center.x - componentWidth / 2,
+    y: schComponent.center.y + componentHeight / 2,
   })
   const componentScreenBottomRight = applyToPoint(transform, {
-    x: schComponent.center.x + schComponent.size.width / 2,
-    y: schComponent.center.y - schComponent.size.height / 2,
+    x: schComponent.center.x + componentWidth / 2,
+    y: schComponent.center.y - componentHeight / 2,
   })
   const componentScreenWidth =
     componentScreenBottomRight.x - componentScreenTopLeft.x

--- a/lib/utils/to-svg-length.ts
+++ b/lib/utils/to-svg-length.ts
@@ -1,0 +1,10 @@
+/**
+ * Clamps a computed length so it can be written into an SVG attribute.
+ *
+ * Per the SVG spec a negative value for `r`, `width` or `height` is an error and
+ * renderers must not draw the shape, and `NaN`/`Infinity` are not lengths at
+ * all. Either way the element silently disappears instead of merely looking
+ * wrong, so clamp to 0 and keep the surrounding markup well-formed.
+ */
+export const toSvgLength = (value: number): number =>
+  Number.isFinite(value) && value > 0 ? value : 0

--- a/tests/pcb/negative-svg-lengths.test.ts
+++ b/tests/pcb/negative-svg-lengths.test.ts
@@ -1,0 +1,145 @@
+import { expect, test } from "bun:test"
+import {
+  convertCircuitJsonToPcbSvg,
+  convertCircuitJsonToSchematicSvg,
+} from "lib"
+
+const board = {
+  type: "pcb_board",
+  pcb_board_id: "board0",
+  center: { x: 0, y: 0 },
+  width: 20,
+  height: 20,
+}
+
+// Per the SVG spec a negative `r`, `width` or `height` is an error and the shape
+// is not rendered, so these must never reach the output.
+const negativeLengthsIn = (svg: string) => [
+  ...new Set(
+    [...svg.matchAll(/ (r|width|height)="(-[\d.]+)"/g)].map(
+      (m) => `${m[1]}=${m[2]}`,
+    ),
+  ),
+]
+
+const radiiIn = (svg: string, dataType: string) => {
+  const group = svg.match(
+    new RegExp(`<g data-type="${dataType}"[\\s\\S]*?</g>`),
+  )?.[0]
+  return [...(group ?? "").matchAll(/ r="([^"]*)"/g)].map((m) => Number(m[1]))
+}
+
+test("a negative via diameter does not emit a negative radius", () => {
+  const svg = convertCircuitJsonToPcbSvg([
+    board,
+    {
+      type: "pcb_via",
+      pcb_via_id: "via0",
+      x: 3,
+      y: 3,
+      outer_diameter: -2,
+      hole_diameter: -1,
+      layers: ["top", "bottom"],
+    },
+  ] as any)
+
+  expect(negativeLengthsIn(svg)).toEqual([])
+})
+
+test("a negative plated hole diameter does not emit a negative radius", () => {
+  const svg = convertCircuitJsonToPcbSvg([
+    board,
+    {
+      type: "pcb_plated_hole",
+      pcb_plated_hole_id: "ph0",
+      shape: "circle",
+      x: 3,
+      y: 3,
+      outer_diameter: -2,
+      hole_diameter: -1,
+      layers: ["top", "bottom"],
+    },
+  ] as any)
+
+  expect(negativeLengthsIn(svg)).toEqual([])
+})
+
+test("a negative unplated hole diameter does not emit a negative radius", () => {
+  const svg = convertCircuitJsonToPcbSvg([
+    board,
+    {
+      type: "pcb_hole",
+      pcb_hole_id: "hole0",
+      hole_shape: "circle",
+      hole_diameter: -2,
+      x: 3,
+      y: 3,
+    },
+  ] as any)
+
+  expect(negativeLengthsIn(svg)).toEqual([])
+})
+
+test("a negative keepout radius does not emit a negative radius", () => {
+  const svg = convertCircuitJsonToPcbSvg([
+    board,
+    {
+      type: "pcb_keepout",
+      pcb_keepout_id: "keepout0",
+      shape: "circle",
+      center: { x: 3, y: 3 },
+      radius: -1,
+      layers: ["top"],
+    },
+  ] as any)
+
+  expect(negativeLengthsIn(svg)).toEqual([])
+})
+
+test("a negative schematic component size does not emit a negative width", () => {
+  const svg = convertCircuitJsonToSchematicSvg([
+    {
+      type: "schematic_component",
+      schematic_component_id: "sc1",
+      center: { x: 0, y: 0 },
+      rotation: 0,
+      size: { width: -4, height: 1 },
+      pin_spacing: 0.2,
+      port_labels: {},
+      source_component_id: "src1",
+    },
+    {
+      type: "source_component",
+      source_component_id: "src1",
+      ftype: "simple_chip",
+      name: "U1",
+    },
+  ] as any)
+
+  expect(negativeLengthsIn(svg)).toEqual([])
+})
+
+test("valid dimensions are still rendered verbatim", () => {
+  // Guards against clamping every length to zero.
+  const svgFor = (outer: number, hole: number) =>
+    convertCircuitJsonToPcbSvg([
+      board,
+      {
+        type: "pcb_via",
+        pcb_via_id: "via0",
+        x: 3,
+        y: 3,
+        outer_diameter: outer,
+        hole_diameter: hole,
+        layers: ["top", "bottom"],
+      },
+    ] as any)
+
+  const radii = radiiIn(svgFor(0.6, 0.3), "pcb_via")
+
+  expect(radii).toHaveLength(2)
+  expect(radii[0]).toBeGreaterThan(0)
+  expect(radii[1]).toBeGreaterThan(0)
+  // outer_diameter is twice hole_diameter, so the radii must keep that ratio.
+  expect(radii[0]! / radii[1]!).toBeCloseTo(2, 6)
+})


### PR DESCRIPTION
Fixes #640.

> Same family as #635 / #637 / #639 (non-finite lengths), but a **different failure mode**: those emitted `NaN`, these emit a well-formed *negative* number that the SVG spec still refuses to draw. This branch is cut from `main` and **does not depend on those PRs** — it touches overlapping files, so if you merge any of them first I'll rebase immediately.

### What was wrong

Per the SVG spec a negative `r`, `width` or `height` is an error and the shape **must not be rendered**. Five paths emitted them:

| input | emitted |
|---|---|
| `<via holeDiameter={-1} outerDiameter={-2} />` | `r="-27.27"`, `r="-13.63"` |
| `<platedhole holeDiameter={-1} shape="circle" />` | `r="-27.27"` |
| `<hole diameter={-2} />` | `r="-27.27"` |
| `<keepout shape="circle" radius={-1} />` | `r="-27.27"` |
| `<chip schWidth={-4} />` | `width="-926.64"` on the body rect |

The rest of the board draws normally, so it reads as a placement problem rather than a bad value.

The schematic case has a different mechanism worth noting: a negative `size.width` **flips the two corners**, so the derived width comes out negative. Clamping the size at the source (rather than the derived width) is what keeps every coordinate below it consistent.

### The fix

One shared helper, `lib/utils/to-svg-length.ts`:

```ts
export const toSvgLength = (value: number): number =>
  Number.isFinite(value) && value > 0 ? value : 0
```

Applied at the five sites where a length is computed — not at each `.toString()` call. That matters in two places: `maskRadius` in both hole renderers is derived from `radius`, so clamping the radius covers the soldermask circles without touching them.

The `Number.isFinite` half also makes this robust to `NaN`/`Infinity`, consistent with the existing pattern in `lib/sim/simulation-graph-svg/format-value-with-unit.ts`.

### Scope

The five paths with a demonstrated failure. I swept the PCB and schematic renderers for negative-length leaks and these were the ones that reproduce end-to-end from a real `tscircuit` circuit; I didn't blanket-wrap every numeric attribute, which would be speculative.

Upstream, `tscircuit/core` accepts these values without error today (filed as tscircuit/core#2857 for the PCB side and tscircuit/core#2861 for the schematic side). Circuit JSON has several producers, so the renderer shouldn't depend on that being fixed first.

### Tests

`tests/pcb/negative-svg-lengths.test.ts`, six tests:

| case | expected |
|---|---|
| via `-2` / `-1` | no negative `r`/`width`/`height` anywhere |
| plated hole `-2` / `-1` | same |
| unplated hole `-2` | same |
| keepout radius `-1` | same |
| schematic component `width: -4` | same |
| valid via `0.6` / `0.3` | both radii **> 0**, and their ratio is **2**, matching the diameters |

The last row is the guard rail: a fix that clamped everything to `0` would pass a bare "no negative lengths" check but fails this.

Bite-proofed: reverting `lib/` takes the file from **6 pass** to **1 pass / 5 fail** — only the valid-input test survives, which is exactly right.

### Verification

`bun test`: **297 pass / 0 fail** (baseline on `main` is 291 pass / 0 fail; +6 new). No snapshot churn. `bunx tsc --noEmit` clean, `bun run format:check` clean.
