### PR TITLE
fix: keep negative and non-finite lengths out of SVG attributes (#640)

### DIFF
--- a/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-hole.ts
+++ b/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-hole.ts
@@ -1,6 +1,7 @@
 import type { PCBHole } from "circuit-json"
 import { applyToPoint } from "transformation-matrix"
 import type { SvgObject } from "lib/svg-object"
+import { toSvgLength } from "lib/utils/to-svg-length"
 import type { PcbContext } from "../convert-circuit-json-to-pcb-svg"
 
 export function createSvgObjectsFromPcbHole(
@@ -26,7 +27,7 @@ export function createSvgObjectsFromPcbHole(
 
   if (hole.hole_shape === "circle" || hole.hole_shape === "square") {
     const scaledDiameter = hole.hole_diameter * Math.abs(transform.a)
-    const radius = scaledDiameter / 2
+    const radius = toSvgLength(scaledDiameter / 2)
 
     if (hole.hole_shape === "circle") {
       const holeElement: SvgObject = {

--- a/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-keepout.ts
+++ b/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-keepout.ts
@@ -1,5 +1,6 @@
 import type { PCBKeepoutRect, PCBKeepoutCircle, Point } from "circuit-json"
 import type { SvgObject } from "lib/svg-object"
+import { toSvgLength } from "lib/utils/to-svg-length"
 import {
   applyToPoint,
   compose,
@@ -186,7 +187,9 @@ export function createSvgObjectsFromPcbKeepout(
         circleKeepout.center.x,
         circleKeepout.center.y,
       ])
-      const scaledRadius = circleKeepout.radius * Math.abs(transform.a)
+      const scaledRadius = toSvgLength(
+        circleKeepout.radius * Math.abs(transform.a),
+      )
 
       const backgroundAttributes = {
         ...createKeepoutBaseAttributes(

--- a/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-plated-hole.ts
+++ b/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-plated-hole.ts
@@ -6,6 +6,7 @@ import type {
 } from "circuit-json"
 import { applyToPoint } from "transformation-matrix"
 import type { SvgObject } from "lib/svg-object"
+import { toSvgLength } from "lib/utils/to-svg-length"
 import type { PcbContext } from "../convert-circuit-json-to-pcb-svg"
 import { getPadDataAttributes } from "./get-pad-data-attributes"
 
@@ -274,8 +275,12 @@ export function createSvgObjectsFromPcbPlatedHole(
     const scaledHoleWidth = hole.hole_diameter * Math.abs(transform.a)
     const scaledHoleHeight = hole.hole_diameter * Math.abs(transform.a)
 
-    const outerRadius = Math.min(scaledOuterWidth, scaledOuterHeight) / 2
-    const innerRadius = Math.min(scaledHoleWidth, scaledHoleHeight) / 2
+    const outerRadius = toSvgLength(
+      Math.min(scaledOuterWidth, scaledOuterHeight) / 2,
+    )
+    const innerRadius = toSvgLength(
+      Math.min(scaledHoleWidth, scaledHoleHeight) / 2,
+    )
 
     let children: SvgObject[] = [
       {

--- a/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-via.ts
+++ b/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-via.ts
@@ -1,5 +1,6 @@
 import type { PCBVia } from "circuit-json"
 import { applyToPoint } from "transformation-matrix"
+import { toSvgLength } from "lib/utils/to-svg-length"
 import type { PcbContext } from "../convert-circuit-json-to-pcb-svg"
 
 export function createSvgObjectsFromPcbVia(hole: PCBVia, ctx: PcbContext): any {
@@ -10,8 +11,12 @@ export function createSvgObjectsFromPcbVia(hole: PCBVia, ctx: PcbContext): any {
   const scaledHoleWidth = hole.hole_diameter * Math.abs(transform.a)
   const scaledHoleHeight = hole.hole_diameter * Math.abs(transform.a)
 
-  const outerRadius = Math.min(scaledOuterWidth, scaledOuterHeight) / 2
-  const innerRadius = Math.min(scaledHoleWidth, scaledHoleHeight) / 2
+  const outerRadius = toSvgLength(
+    Math.min(scaledOuterWidth, scaledOuterHeight) / 2,
+  )
+  const innerRadius = toSvgLength(
+    Math.min(scaledHoleWidth, scaledHoleHeight) / 2,
+  )
   return {
     name: "g",
     type: "element",

--- a/lib/sch/svg-object-fns/create-svg-objects-from-sch-component-with-box.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-from-sch-component-with-box.ts
@@ -7,6 +7,7 @@ import type {
 } from "circuit-json"
 import type { SvgObject } from "lib/svg-object"
 import type { ColorMap } from "lib/utils/colors"
+import { toSvgLength } from "lib/utils/to-svg-length"
 import { getSvg, symbols } from "schematic-symbols"
 import { parseSync } from "svgson"
 import { applyToPoint, type Matrix } from "transformation-matrix"
@@ -37,10 +38,12 @@ export const createSvgObjectsFromSchematicComponentWithBox = ({
     x: schComponent.center.x + schComponent.size.width / 2,
     y: schComponent.center.y - schComponent.size.height / 2,
   })
-  const componentScreenWidth =
-    componentScreenBottomRight.x - componentScreenTopLeft.x
-  const componentScreenHeight =
-    componentScreenBottomRight.y - componentScreenTopLeft.y
+  const componentScreenWidth = toSvgLength(
+    componentScreenBottomRight.x - componentScreenTopLeft.x,
+  )
+  const componentScreenHeight = toSvgLength(
+    componentScreenBottomRight.y - componentScreenTopLeft.y,
+  )
 
   // Add basic rectangle for component body
   svgObjects.push({

--- a/lib/utils/to-svg-length.ts
+++ b/lib/utils/to-svg-length.ts
@@ -1,0 +1,11 @@
+/**
+ * Clamps a computed length so it is safe to write into an SVG attribute.
+ *
+ * Per the SVG spec a negative value for `r`, `width` or `height` is an error and
+ * renderers must not draw the shape, and `NaN`/`Infinity` are not lengths at
+ * all. In both cases the element silently disappears rather than merely looking
+ * wrong, which hides the real problem, so clamp to 0 and keep the surrounding
+ * markup well-formed.
+ */
+export const toSvgLength = (value: number): number =>
+  Number.isFinite(value) && value > 0 ? value : 0

--- a/tests/pcb/negative-svg-lengths.test.ts
+++ b/tests/pcb/negative-svg-lengths.test.ts
@@ -1,0 +1,136 @@
+import { expect, test } from "bun:test"
+import { convertCircuitJsonToPcbSvg } from "lib"
+import type { AnyCircuitElement } from "circuit-json"
+
+const board: AnyCircuitElement = {
+  type: "pcb_board",
+  pcb_board_id: "board0",
+  center: { x: 0, y: 0 },
+  width: 20,
+  height: 20,
+  thickness: 1.6,
+  num_layers: 2,
+  material: "fr4",
+} as AnyCircuitElement
+
+/**
+ * Per the SVG spec a negative `r`, `width` or `height` is an error and the
+ * shape must not be rendered, and NaN/Infinity are not lengths at all. Either
+ * way the element silently disappears instead of merely looking wrong, so no
+ * length attribute may ever carry one of these values.
+ */
+const INVALID_LENGTH =
+  /(?:^|\s)(?:r|rx|ry|width|height)="(-[\d.]+|-?Infinity|NaN)"/g
+
+const findInvalidLengths = (svg: string): string[] => [
+  ...new Set([...svg.matchAll(INVALID_LENGTH)].map((m) => m[0].trim())),
+]
+
+test("negative via diameters do not emit negative SVG lengths", () => {
+  const svg = convertCircuitJsonToPcbSvg([
+    board,
+    {
+      type: "pcb_via",
+      pcb_via_id: "via0",
+      x: 3,
+      y: 3,
+      hole_diameter: -1,
+      outer_diameter: -2,
+      layers: ["top", "bottom"],
+    } as AnyCircuitElement,
+  ])
+
+  expect(findInvalidLengths(svg)).toEqual([])
+})
+
+test("negative hole diameter does not emit a negative SVG length", () => {
+  const svg = convertCircuitJsonToPcbSvg([
+    board,
+    {
+      type: "pcb_hole",
+      pcb_hole_id: "hole0",
+      x: 2,
+      y: 2,
+      hole_shape: "circle",
+      hole_diameter: -2,
+    } as AnyCircuitElement,
+  ])
+
+  expect(findInvalidLengths(svg)).toEqual([])
+})
+
+test("negative plated hole diameters do not emit negative SVG lengths", () => {
+  const svg = convertCircuitJsonToPcbSvg([
+    board,
+    {
+      type: "pcb_plated_hole",
+      pcb_plated_hole_id: "ph0",
+      x: -3,
+      y: -3,
+      shape: "circle",
+      hole_diameter: -1,
+      outer_diameter: -2,
+      layers: ["top", "bottom"],
+    } as AnyCircuitElement,
+  ])
+
+  expect(findInvalidLengths(svg)).toEqual([])
+})
+
+test("negative keepout radius does not emit a negative SVG length", () => {
+  const svg = convertCircuitJsonToPcbSvg([
+    board,
+    {
+      type: "pcb_keepout",
+      pcb_keepout_id: "ko0",
+      center: { x: 0, y: 5 },
+      shape: "circle",
+      radius: -1,
+      layers: ["top"],
+    } as AnyCircuitElement,
+  ])
+
+  expect(findInvalidLengths(svg)).toEqual([])
+})
+
+test("non-finite via diameters do not emit NaN or Infinity radii", () => {
+  const svg = convertCircuitJsonToPcbSvg([
+    board,
+    {
+      type: "pcb_via",
+      pcb_via_id: "via_nan",
+      x: 0,
+      y: 0,
+      hole_diameter: Number.NaN,
+      outer_diameter: Number.POSITIVE_INFINITY,
+      layers: ["top", "bottom"],
+    } as AnyCircuitElement,
+  ])
+
+  // Scoped to the radii this conversion owns. A non-finite dimension also
+  // poisons the viewport transform, which leaves NaN in `cx`/`cy` and in the
+  // board outline; that is a separate defect in the bounds calculation and is
+  // deliberately not addressed here.
+  const viaRadii = [...svg.matchAll(/data-type="pcb_via"/g)].length
+  expect(viaRadii).toBeGreaterThan(0)
+  expect(svg).not.toMatch(/r="(-[\d.]+|-?Infinity|NaN)"/)
+})
+
+test("valid dimensions still render their lengths unchanged", () => {
+  const svg = convertCircuitJsonToPcbSvg([
+    board,
+    {
+      type: "pcb_via",
+      pcb_via_id: "via_ok",
+      x: 0,
+      y: 0,
+      hole_diameter: 0.4,
+      outer_diameter: 0.8,
+      layers: ["top", "bottom"],
+    } as AnyCircuitElement,
+  ])
+
+  expect(findInvalidLengths(svg)).toEqual([])
+  // a positive radius must survive untouched, otherwise the clamp is too eager
+  expect(svg).toMatch(/class="pcb-hole-outer"[^>]*r="[\d.]+"/)
+})

--- a/tests/sch/negative-svg-lengths.test.ts
+++ b/tests/sch/negative-svg-lengths.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test"
+import { convertCircuitJsonToSchematicSvg } from "lib"
+import type { AnyCircuitElement } from "circuit-json"
+
+const chipWithSize = (width: number, height: number): AnyCircuitElement[] => [
+  {
+    type: "schematic_component",
+    schematic_component_id: "sc0",
+    center: { x: 0, y: 0 },
+    size: { width, height },
+    source_component_id: "src0",
+  } as unknown as AnyCircuitElement,
+  {
+    type: "source_component",
+    source_component_id: "src0",
+    name: "U1",
+    ftype: "simple_chip",
+  } as unknown as AnyCircuitElement,
+]
+
+const bodyRect = (svg: string): string =>
+  svg.match(/class="component chip sch-component-body"[^>]*/)?.[0] ?? ""
+
+test("negative schematic component size does not emit a negative width", () => {
+  const svg = convertCircuitJsonToSchematicSvg(chipWithSize(-4, 2))
+
+  // A negative size.width flips the two corners, so the derived screen width
+  // came out negative and the body rect was dropped by the renderer.
+  expect(bodyRect(svg)).not.toMatch(/width="-[\d.]+"/)
+  expect(bodyRect(svg)).toMatch(/width="0"/)
+})
+
+test("valid schematic component size still renders its width", () => {
+  const svg = convertCircuitJsonToSchematicSvg(chipWithSize(4, 2))
+
+  expect(bodyRect(svg)).not.toMatch(/width="(-[\d.]+|0)"/)
+  expect(bodyRect(svg)).toMatch(/width="[\d.]+"/)
+})


### PR DESCRIPTION
Per the SVG spec a negative `r`, `width` or `height` is an error and the shape must not be rendered, so elements silently disappeared instead of merely looking wrong. NaN/Infinity are not lengths at all and had the same effect.

Adds `toSvgLength()` and clamps at the point each length is computed, so every attribute derived from it is covered:

- pcb_via     outer/inner radius
- pcb_hole    circle radius
- pcb_plated_hole  outer/inner radius
- pcb_keepout circle radius
- schematic component body width/height (a negative size.width flips the
  two corners, so the derived screen width came out negative)

Valid dimensions are untouched.

Note: a non-finite dimension also poisons the viewport transform, which leaves NaN in `cx`/`cy` and the board outline. That is a separate defect in the bounds calculation and is not addressed here.