### PR TITLE
fix: keep non-finite via/plated-hole radii out of the SVG (#634)

### DIFF
--- a/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-plated-hole.ts
+++ b/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-plated-hole.ts
@@ -277,42 +277,54 @@ export function createSvgObjectsFromPcbPlatedHole(
     const outerRadius = Math.min(scaledOuterWidth, scaledOuterHeight) / 2
     const innerRadius = Math.min(scaledHoleWidth, scaledHoleHeight) / 2
 
-    let children: SvgObject[] = [
-      {
-        name: "circle",
-        type: "element",
-        attributes: {
-          class: "pcb-hole-outer",
-          fill: colorMap.copper.top,
-          cx: x.toString(),
-          cy: y.toString(),
-          r: outerRadius.toString(),
-          "data-type": "pcb_plated_hole",
-          "data-pcb-layer": layer,
-        },
-        value: "",
-        children: [],
-      },
-      {
-        name: "circle",
-        type: "element",
-        attributes: {
-          class: "pcb-hole-inner",
-          fill: colorMap.drill,
+    // A non-finite diameter (e.g. an unparseable `outer_diameter`/`hole_diameter`
+    // arriving as NaN) would stringify to r="NaN", which is not a valid SVG
+    // length — renderers discard the whole <circle>. Build only the circles
+    // whose radius is finite instead of emitting broken markup. See
+    // tscircuit/circuit-to-svg#634.
+    const outerCircle: SvgObject | null = Number.isFinite(outerRadius)
+      ? {
+          name: "circle",
+          type: "element",
+          attributes: {
+            class: "pcb-hole-outer",
+            fill: colorMap.copper.top,
+            cx: x.toString(),
+            cy: y.toString(),
+            r: outerRadius.toString(),
+            "data-type": "pcb_plated_hole",
+            "data-pcb-layer": layer,
+          },
+          value: "",
+          children: [],
+        }
+      : null
+    const innerCircle: SvgObject | null = Number.isFinite(innerRadius)
+      ? {
+          name: "circle",
+          type: "element",
+          attributes: {
+            class: "pcb-hole-inner",
+            fill: colorMap.drill,
 
-          cx: x.toString(),
-          cy: y.toString(),
-          r: innerRadius.toString(),
-          "data-type": "pcb_plated_hole_drill",
-          "data-pcb-layer": "drill",
-        },
-        value: "",
-        children: [],
-      },
-    ]
+            cx: x.toString(),
+            cy: y.toString(),
+            r: innerRadius.toString(),
+            "data-type": "pcb_plated_hole_drill",
+            "data-pcb-layer": "drill",
+          },
+          value: "",
+          children: [],
+        }
+      : null
 
-    // Add soldermask if needed
-    if (shouldShowSolderMask) {
+    let children: SvgObject[] = [outerCircle, innerCircle].filter(
+      (c): c is SvgObject => c !== null,
+    )
+
+    // Add soldermask if needed. The mask geometry is derived from outerRadius,
+    // so skip it when outerRadius is non-finite (it would emit r="NaN" too).
+    if (shouldShowSolderMask && Number.isFinite(outerRadius)) {
       const maskRadius = outerRadius + soldermaskMargin
 
       // For negative margins, create a ring effect
@@ -351,8 +363,8 @@ export function createSvgObjectsFromPcbPlatedHole(
             value: "",
             children: [],
           },
-          // 3. Draw the drill hole on top
-          children[1] as SvgObject, // Original inner hole
+          // 3. Draw the drill hole on top (omitted if its radius is non-finite)
+          ...(innerCircle ? [innerCircle] : []),
         ]
       } else {
         // For positive margins, draw substrate cutout

--- a/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-via.ts
+++ b/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-via.ts
@@ -12,6 +12,44 @@ export function createSvgObjectsFromPcbVia(hole: PCBVia, ctx: PcbContext): any {
 
   const outerRadius = Math.min(scaledOuterWidth, scaledOuterHeight) / 2
   const innerRadius = Math.min(scaledHoleWidth, scaledHoleHeight) / 2
+
+  // A non-finite diameter (e.g. an unparseable `outer_diameter`/`hole_diameter`
+  // arriving as NaN) would stringify to r="NaN", which is not a valid SVG
+  // length — renderers discard the whole <circle>. Skip the invalid circle
+  // instead of emitting broken markup. See tscircuit/circuit-to-svg#634.
+  const children = []
+  if (Number.isFinite(outerRadius)) {
+    children.push({
+      name: "circle",
+      type: "element",
+      attributes: {
+        class: "pcb-hole-outer",
+        fill: colorMap.copper.top,
+        cx: x.toString(),
+        cy: y.toString(),
+        r: outerRadius.toString(),
+        "data-type": "pcb_via",
+        "data-pcb-layer": "top",
+      },
+    })
+  }
+  if (Number.isFinite(innerRadius)) {
+    children.push({
+      name: "circle",
+      type: "element",
+      attributes: {
+        class: "pcb-hole-inner",
+        fill: colorMap.drill,
+
+        cx: x.toString(),
+        cy: y.toString(),
+        r: innerRadius.toString(),
+        "data-type": "pcb_via",
+        "data-pcb-layer": "drill",
+      },
+    })
+  }
+
   return {
     name: "g",
     type: "element",
@@ -19,34 +57,6 @@ export function createSvgObjectsFromPcbVia(hole: PCBVia, ctx: PcbContext): any {
       "data-type": "pcb_via",
       "data-pcb-layer": "through",
     },
-    children: [
-      {
-        name: "circle",
-        type: "element",
-        attributes: {
-          class: "pcb-hole-outer",
-          fill: colorMap.copper.top,
-          cx: x.toString(),
-          cy: y.toString(),
-          r: outerRadius.toString(),
-          "data-type": "pcb_via",
-          "data-pcb-layer": "top",
-        },
-      },
-      {
-        name: "circle",
-        type: "element",
-        attributes: {
-          class: "pcb-hole-inner",
-          fill: colorMap.drill,
-
-          cx: x.toString(),
-          cy: y.toString(),
-          r: innerRadius.toString(),
-          "data-type": "pcb_via",
-          "data-pcb-layer": "drill",
-        },
-      },
-    ],
+    children,
   }
 }

--- a/tests/pcb/non-finite-hole-diameter.test.ts
+++ b/tests/pcb/non-finite-hole-diameter.test.ts
@@ -1,0 +1,81 @@
+import { test, expect } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToPcbSvg } from "lib"
+
+// Regression for tscircuit/circuit-to-svg#634: a via or plated hole whose
+// diameter is non-finite (an unparseable value reaches the renderer as NaN on
+// the in-memory path tscircuit produces) must not emit r="NaN". A NaN SVG
+// length is invalid, so renderers discard the whole <circle> and the drill
+// silently disappears. The renderer should omit the invalid circle instead.
+
+const board: AnyCircuitElement[] = [
+  {
+    type: "pcb_board",
+    pcb_board_id: "board0",
+    center: { x: 0, y: 0 },
+    width: 20,
+    height: 20,
+    thickness: 1.4,
+    num_layers: 2,
+    material: "fr4",
+  } as any,
+]
+
+test("via with non-finite hole_diameter does not emit r=NaN", () => {
+  const svg = convertCircuitJsonToPcbSvg([
+    ...board,
+    {
+      type: "pcb_via",
+      pcb_via_id: "via_0",
+      x: 3,
+      y: 3,
+      outer_diameter: 0.6,
+      hole_diameter: Number.NaN,
+      layers: ["top", "bottom"],
+    } as any,
+  ])
+
+  expect(svg).not.toContain("NaN")
+  // the finite outer copper circle still renders; only the invalid drill is dropped
+  expect(svg).not.toContain('class="pcb-hole-inner"')
+  expect(svg).toContain('class="pcb-hole-outer"')
+})
+
+test("circular plated hole with non-finite hole_diameter does not emit r=NaN", () => {
+  const svg = convertCircuitJsonToPcbSvg([
+    ...board,
+    {
+      type: "pcb_plated_hole",
+      pcb_plated_hole_id: "ph_0",
+      shape: "circle",
+      x: 5,
+      y: 5,
+      outer_diameter: 1,
+      hole_diameter: Number.NaN,
+      layers: ["top", "bottom"],
+    } as any,
+  ])
+
+  expect(svg).not.toContain("NaN")
+  expect(svg).not.toContain('class="pcb-hole-inner"')
+  expect(svg).toContain('class="pcb-hole-outer"')
+})
+
+test("via with finite diameters is unchanged (still renders both circles)", () => {
+  const svg = convertCircuitJsonToPcbSvg([
+    ...board,
+    {
+      type: "pcb_via",
+      pcb_via_id: "via_1",
+      x: 3,
+      y: 3,
+      outer_diameter: 0.6,
+      hole_diameter: 0.3,
+      layers: ["top", "bottom"],
+    } as any,
+  ])
+
+  expect(svg).not.toContain("NaN")
+  expect(svg).toContain('class="pcb-hole-outer"')
+  expect(svg).toContain('class="pcb-hole-inner"')
+})


### PR DESCRIPTION
Fixes #634.

### Problem
A via or circular plated hole whose diameter is non-finite renders as `r="NaN"`. A `NaN` SVG length is invalid, so renderers discard the whole `<circle>` — the drill silently disappears while the rest of the board renders fine, so it reads as a placement bug rather than a bad value.

The value is `NaN` in memory but `null` after JSON serialisation (`null / 2 === 0`, which renders harmlessly), so this only shows on the in-memory path `tscircuit` produces — which is how the converter is normally called.

### Fix
- `create-svg-objects-from-pcb-via.ts`: build each circle only when `Number.isFinite(radius)`, so an invalid drill is omitted instead of emitting `r="NaN"`; a finite outer copper ring still renders when only the hole diameter is bad.
- `create-svg-objects-from-pcb-plated-hole.ts` (`shape === "circle"` branch): same finite guard for the outer/inner circles, and the soldermask geometry (derived from `outerRadius`) is skipped when `outerRadius` is non-finite.

Scope is intentionally limited to the non-finite case filed in #634; negative dimensions (#640) are left alone.

### Tests
Adds `tests/pcb/non-finite-hole-diameter.test.ts` covering the via and the circular plated hole (asserts no `NaN` in the output and that the finite outer circle still renders), plus a finite-input case proving unchanged behaviour. Verified the test fails on `main` and passes with this change; the full `tests/pcb` suite (170 tests, 2 snapshots) still passes and `tsc --noEmit` is clean.

---
**Disclosure:** This PR was written by an AI agent (Claude, operating autonomously). The diagnosis, code, and tests were produced and verified by the agent (`bun test` green locally). Happy to adjust the approach — e.g. route through `formatNumber` for an `r="0"` fallback instead of omission — if you prefer a different convention.