### PR TITLE
Render SMT pad solder paste margin fallbacks

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
         "@vitejs/plugin-react": "5.0.0",
         "biome": "^0.3.3",
         "bun-match-svg": "^0.0.12",
-        "circuit-json": "^0.0.456",
+        "circuit-json": "^0.0.463",
         "esbuild": "^0.20.2",
         "format-si-unit": "^0.0.7",
         "performance-now": "^2.1.0",
@@ -530,7 +530,7 @@
 
     "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
-    "circuit-json": ["circuit-json@0.0.456", "", { "peerDependencies": { "format-si-unit": "*" } }, "sha512-iqcNnSxr1IOIwB3voMMcylrf1sVq3pQs/EJXeOtPBhdLOVVbe8eo5rXY39LE9535T2ywFv6l8tK1LM630y9JPg=="],
+    "circuit-json": ["circuit-json@0.0.463", "", { "peerDependencies": { "format-si-unit": "*" } }, "sha512-XJcAmO2miO5F9hUcdDWihCrynb8vNfDMyNNHjhg0/N2I9rN1ew2bqhJr7zV3RP4QZI2IwMu36PJXWPDQ5Q9cww=="],
 
     "circuit-json-to-bpc": ["circuit-json-to-bpc@0.0.13", "", { "peerDependencies": { "bpc-graph": "*", "circuit-json": "*", "typescript": "^5" } }, "sha512-3wSMtPa6tJkiBQN4tsm7f0Mb7Wp90X2c8dNbULoDVE4mGGoFqP1DXqBlyvvZZl+4SjqznzQQ0EioLe2SCQTOcg=="],
 

--- a/lib/pcb/convert-circuit-json-to-pcb-svg.ts
+++ b/lib/pcb/convert-circuit-json-to-pcb-svg.ts
@@ -78,6 +78,7 @@ import { sortSvgObjectsByPcbLayer } from "./sort-svg-objects-by-pcb-layer"
 import { createErrorTextOverlay } from "../utils/create-error-text-overlay"
 import { getComprehensivePcbBounds } from "./get-pcb-bounds-from-circuit-json"
 import { getViewportBounds } from "../utils/get-viewport-bounds"
+import { createSvgObjectsFromSmtPadSolderPaste } from "./svg-object-fns/create-svg-objects-from-smtpad-solder-paste"
 interface PointObjectNotation {
   x: number
   y: number
@@ -473,7 +474,12 @@ function createSvgObjects({
     case "pcb_hole":
       return createSvgObjectsFromPcbHole(elm, ctx)
     case "pcb_smtpad":
-      return createSvgObjectsFromSmtPad(elm, ctx)
+      return [
+        ...createSvgObjectsFromSmtPad(elm, ctx),
+        ...(ctx.showSolderPaste
+          ? createSvgObjectsFromSmtPadSolderPaste(elm, ctx)
+          : []),
+      ]
     case "pcb_solder_paste":
       return ctx.showSolderPaste
         ? createSvgObjectsFromSolderPaste(elm, ctx)

--- a/lib/pcb/convert-circuit-json-to-solder-paste-mask.ts
+++ b/lib/pcb/convert-circuit-json-to-solder-paste-mask.ts
@@ -15,9 +15,11 @@ import { DEFAULT_PCB_COLOR_MAP } from "./colors"
 import { getSoftwareUsedString } from "../utils/get-software-used-string"
 import { CIRCUIT_TO_SVG_VERSION } from "../package-version"
 import { createErrorTextOverlay } from "../utils/create-error-text-overlay"
+import { createSvgObjectsFromSmtPadSolderPaste } from "./svg-object-fns/create-svg-objects-from-smtpad-solder-paste"
 
 const OBJECT_ORDER: AnyCircuitElement["type"][] = [
   "pcb_board",
+  "pcb_smtpad",
   "pcb_solder_paste",
 ]
 
@@ -38,12 +40,16 @@ export function convertCircuitJsonToSolderPasteMask(
   let maxX = Number.NEGATIVE_INFINITY
   let maxY = Number.NEGATIVE_INFINITY
 
-  // Filter to include only pcb_board and pcb_solder_paste elements for the specified layer
+  // Include explicit paste and pads that can provide paste as a fallback.
   const filteredCircuitJson = circuitJson.filter(
     (elm) =>
       elm.type === "pcb_board" ||
       elm.type === "pcb_panel" ||
-      (elm.type === "pcb_solder_paste" && elm.layer === options.layer),
+      (elm.type === "pcb_solder_paste" && elm.layer === options.layer) ||
+      (elm.type === "pcb_smtpad" &&
+        elm.layer === options.layer &&
+        "solderpaste_margin" in elm &&
+        typeof elm.solderpaste_margin === "number"),
   )
 
   // Process filtered elements to determine bounds
@@ -68,6 +74,12 @@ export function convertCircuitJsonToSolderPasteMask(
       }
     } else if (item.type === "pcb_solder_paste" && "x" in item && "y" in item) {
       updateBounds({ x: item.x, y: item.y }, 0, 0)
+    } else if (item.type === "pcb_smtpad") {
+      if (item.shape === "polygon") {
+        updateBoundsToIncludeOutline(item.points)
+      } else if ("x" in item && "y" in item) {
+        updateBounds({ x: item.x, y: item.y }, 0, 0)
+      }
     }
   }
 
@@ -99,6 +111,7 @@ export function convertCircuitJsonToSolderPasteMask(
     transform,
     layer: options.layer,
     colorMap: DEFAULT_PCB_COLOR_MAP,
+    circuitJson,
   }
 
   // Sort elements by OBJECT_ORDER and convert to SVG objects
@@ -203,6 +216,8 @@ function createSvgObjects({ elm, ctx }: CreateSvgObjectsParams): SvgObject[] {
       return createSvgObjectsFromPcbBoard(elm, ctx)
     case "pcb_solder_paste":
       return createSvgObjectsFromSolderPaste(elm, ctx)
+    case "pcb_smtpad":
+      return createSvgObjectsFromSmtPadSolderPaste(elm, ctx)
     default:
       return []
   }

--- a/lib/pcb/convert-circuit-json-to-solder-paste-mask.ts
+++ b/lib/pcb/convert-circuit-json-to-solder-paste-mask.ts
@@ -48,7 +48,6 @@ export function convertCircuitJsonToSolderPasteMask(
       (elm.type === "pcb_solder_paste" && elm.layer === options.layer) ||
       (elm.type === "pcb_smtpad" &&
         elm.layer === options.layer &&
-        "solderpaste_margin" in elm &&
         typeof elm.solderpaste_margin === "number"),
   )
 

--- a/lib/pcb/offset-polygon-outline.ts
+++ b/lib/pcb/offset-polygon-outline.ts
@@ -1,0 +1,63 @@
+export type PolygonPoint = { x: number; y: number }
+
+const getSignedPolygonArea = (points: PolygonPoint[]) =>
+  points.reduce((area, point, index) => {
+    const next = points[(index + 1) % points.length]!
+    return area + point.x * next.y - next.x * point.y
+  }, 0) / 2
+
+const getLineIntersection = (
+  lineA: { start: PolygonPoint; end: PolygonPoint },
+  lineB: { start: PolygonPoint; end: PolygonPoint },
+): PolygonPoint | null => {
+  const ax = lineA.end.x - lineA.start.x
+  const ay = lineA.end.y - lineA.start.y
+  const bx = lineB.end.x - lineB.start.x
+  const by = lineB.end.y - lineB.start.y
+  const denominator = ax * by - ay * bx
+  if (Math.abs(denominator) < 1e-9) return null
+
+  const cx = lineB.start.x - lineA.start.x
+  const cy = lineB.start.y - lineA.start.y
+  const t = (cx * by - cy * bx) / denominator
+  return { x: lineA.start.x + ax * t, y: lineA.start.y + ay * t }
+}
+
+export const offsetPolygonOutline = (
+  points: PolygonPoint[],
+  offset: number,
+): PolygonPoint[] => {
+  if (points.length < 3 || offset === 0) return points
+
+  const isCounterClockwise = getSignedPolygonArea(points) > 0
+  const shiftedEdges = points.flatMap((start, index) => {
+    const end = points[(index + 1) % points.length]!
+    const dx = end.x - start.x
+    const dy = end.y - start.y
+    const length = Math.sqrt(dx * dx + dy * dy)
+    if (length < 1e-9) return []
+
+    const normalX = (isCounterClockwise ? dy : -dy) / length
+    const normalY = (isCounterClockwise ? -dx : dx) / length
+    return [
+      {
+        start: {
+          x: start.x + normalX * offset,
+          y: start.y + normalY * offset,
+        },
+        end: {
+          x: end.x + normalX * offset,
+          y: end.y + normalY * offset,
+        },
+      },
+    ]
+  })
+
+  if (shiftedEdges.length < 3) return points
+
+  return shiftedEdges.map((currentEdge, index) => {
+    const previousEdge =
+      shiftedEdges[(index - 1 + shiftedEdges.length) % shiftedEdges.length]!
+    return getLineIntersection(previousEdge, currentEdge) ?? currentEdge.start
+  })
+}

--- a/lib/pcb/svg-object-fns/create-svg-objects-from-smtpad-solder-paste.ts
+++ b/lib/pcb/svg-object-fns/create-svg-objects-from-smtpad-solder-paste.ts
@@ -1,0 +1,126 @@
+import type { PcbSmtPad } from "circuit-json"
+import type { SvgObject } from "lib/svg-object"
+import { applyToPoint } from "transformation-matrix"
+import type { PcbContext } from "../convert-circuit-json-to-pcb-svg"
+import { solderPasteLayerNameToColor } from "../layer-name-to-color"
+import { offsetPolygonOutline } from "../offset-polygon-outline"
+
+type PcbSmtPadWithSolderPasteMargin = PcbSmtPad & {
+  solderpaste_margin?: number
+}
+
+export const createSvgObjectsFromSmtPadSolderPaste = (
+  pad: PcbSmtPadWithSolderPasteMargin,
+  ctx: PcbContext,
+): SvgObject[] => {
+  const margin = pad.solderpaste_margin
+  if (typeof margin !== "number") return []
+  if (ctx.layer && pad.layer !== ctx.layer) return []
+
+  const hasExplicitSolderPaste = ctx.circuitJson?.some(
+    (element) =>
+      element.type === "pcb_solder_paste" &&
+      element.pcb_smtpad_id === pad.pcb_smtpad_id,
+  )
+  if (hasExplicitSolderPaste) return []
+
+  const { transform } = ctx
+  const fill = solderPasteLayerNameToColor(pad.layer)
+  const commonAttributes = {
+    class: "pcb-solder-paste",
+    fill,
+    "data-type": "pcb_solder_paste",
+    "data-pcb-layer": pad.layer,
+    "data-pcb-smtpad-id": pad.pcb_smtpad_id,
+  }
+
+  if (pad.shape === "polygon") {
+    const points = offsetPolygonOutline(pad.points, margin).map((point) =>
+      applyToPoint(transform, [point.x, point.y]),
+    )
+    if (points.length < 3) return []
+    return [
+      {
+        name: "polygon",
+        type: "element",
+        value: "",
+        children: [],
+        attributes: {
+          ...commonAttributes,
+          points: points.map((point) => point.join(",")).join(" "),
+        },
+      },
+    ]
+  }
+
+  const [x, y] = applyToPoint(transform, [pad.x, pad.y])
+  if (pad.shape === "circle") {
+    const radius = pad.radius + margin
+    if (radius <= 0) return []
+    return [
+      {
+        name: "circle",
+        type: "element",
+        value: "",
+        children: [],
+        attributes: {
+          ...commonAttributes,
+          cx: x.toString(),
+          cy: y.toString(),
+          r: (radius * Math.abs(transform.a)).toString(),
+        },
+      },
+    ]
+  }
+
+  const width = pad.width + margin * 2
+  const height = pad.height + margin * 2
+  if (width <= 0 || height <= 0) return []
+
+  const scaledWidth = width * Math.abs(transform.a)
+  const scaledHeight = height * Math.abs(transform.d)
+  const isRotated =
+    (pad.shape === "rotated_rect" || pad.shape === "rotated_pill") &&
+    pad.ccw_rotation !== 0
+  const attributes: Record<string, string> = {
+    ...commonAttributes,
+    x: (isRotated ? -scaledWidth / 2 : x - scaledWidth / 2).toString(),
+    y: (isRotated ? -scaledHeight / 2 : y - scaledHeight / 2).toString(),
+    width: scaledWidth.toString(),
+    height: scaledHeight.toString(),
+  }
+
+  if (isRotated) {
+    attributes.transform = `translate(${x} ${y}) rotate(${-pad.ccw_rotation})`
+  }
+
+  if (pad.shape === "pill" || pad.shape === "rotated_pill") {
+    const radius = Math.max(
+      0,
+      Math.min(pad.radius + margin, width / 2, height / 2),
+    )
+    attributes.rx = (radius * Math.abs(transform.a)).toString()
+  } else {
+    const cornerRadius =
+      "corner_radius" in pad && typeof pad.corner_radius === "number"
+        ? Math.max(
+            0,
+            Math.min(pad.corner_radius + margin, width / 2, height / 2),
+          )
+        : 0
+    if (cornerRadius > 0) {
+      attributes.rx = (cornerRadius * Math.abs(transform.a)).toString()
+      attributes.ry = (cornerRadius * Math.abs(transform.d)).toString()
+    }
+  }
+
+  return [
+    {
+      name: "rect",
+      type: "element",
+      value: "",
+      children: [],
+      attributes,
+    },
+  ]
+}

--- a/lib/pcb/svg-object-fns/create-svg-objects-from-smtpad-solder-paste.ts
+++ b/lib/pcb/svg-object-fns/create-svg-objects-from-smtpad-solder-paste.ts
@@ -5,12 +5,8 @@ import type { PcbContext } from "../convert-circuit-json-to-pcb-svg"
 import { solderPasteLayerNameToColor } from "../layer-name-to-color"
 import { offsetPolygonOutline } from "../offset-polygon-outline"
 
-type PcbSmtPadWithSolderPasteMargin = PcbSmtPad & {
-  solderpaste_margin?: number
-}
-
 export const createSvgObjectsFromSmtPadSolderPaste = (
-  pad: PcbSmtPadWithSolderPasteMargin,
+  pad: PcbSmtPad,
   ctx: PcbContext,
 ): SvgObject[] => {
   const margin = pad.solderpaste_margin

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@vitejs/plugin-react": "5.0.0",
     "biome": "^0.3.3",
     "bun-match-svg": "^0.0.12",
-    "circuit-json": "^0.0.456",
+    "circuit-json": "^0.0.463",
     "esbuild": "^0.20.2",
     "format-si-unit": "^0.0.7",
     "performance-now": "^2.1.0",

--- a/tests/pcb/smtpad-solderpaste-margin.test.ts
+++ b/tests/pcb/smtpad-solderpaste-margin.test.ts
@@ -1,0 +1,99 @@
+import { expect, test } from "bun:test"
+import {
+  convertCircuitJsonToPcbSvg,
+  convertCircuitJsonToSolderPasteMask,
+} from "lib"
+
+const circuitJson = [
+  {
+    type: "pcb_board",
+    pcb_board_id: "pcb_board_0",
+    center: { x: 0, y: 0 },
+    width: 10,
+    height: 10,
+  },
+  {
+    type: "pcb_smtpad",
+    pcb_smtpad_id: "fallback_pad",
+    shape: "rect",
+    layer: "top",
+    x: -2,
+    y: 0,
+    width: 2,
+    height: 1,
+    solderpaste_margin: -0.1,
+  },
+  {
+    type: "pcb_smtpad",
+    pcb_smtpad_id: "explicit_pad",
+    shape: "rect",
+    layer: "top",
+    x: 2,
+    y: 0,
+    width: 2,
+    height: 1,
+    solderpaste_margin: -0.2,
+  },
+  {
+    type: "pcb_solder_paste",
+    pcb_solder_paste_id: "explicit_paste",
+    pcb_smtpad_id: "explicit_pad",
+    shape: "rect",
+    layer: "top",
+    x: 2,
+    y: 0,
+    width: 0.5,
+    height: 0.25,
+  },
+] as any
+
+test("solder paste mask uses pad margin only when explicit paste is absent", () => {
+  const svg = convertCircuitJsonToSolderPasteMask(circuitJson, {
+    layer: "top",
+  })
+
+  expect(svg.match(/class="pcb-solder-paste"/g)).toHaveLength(2)
+  expect(svg).toContain('data-pcb-smtpad-id="fallback_pad"')
+  expect(svg).not.toContain('data-pcb-smtpad-id="explicit_pad"')
+  expect(svg).toContain('width="90" height="40"')
+  expect(svg).toContain('width="25" height="12.5"')
+})
+
+test("showSolderPaste renders pad-margin fallback paste", () => {
+  const svg = convertCircuitJsonToPcbSvg(circuitJson, {
+    layer: "top",
+    width: 600,
+    height: 600,
+    showSolderPaste: true,
+  })
+
+  expect(svg.match(/class="pcb-solder-paste"/g)).toHaveLength(2)
+  expect(svg).toContain('data-pcb-smtpad-id="fallback_pad"')
+  expect(svg).not.toContain('data-pcb-smtpad-id="explicit_pad"')
+})
+
+test("polygon pad margin renders fallback paste as an offset polygon", () => {
+  const svg = convertCircuitJsonToSolderPasteMask(
+    [
+      circuitJson[0],
+      {
+        type: "pcb_smtpad",
+        pcb_smtpad_id: "polygon_pad",
+        shape: "polygon",
+        layer: "top",
+        points: [
+          { x: -1, y: -1 },
+          { x: 1, y: -1 },
+          { x: 1, y: 1 },
+          { x: -1, y: 1 },
+        ],
+        solderpaste_margin: -0.2,
+      },
+    ] as any,
+    { layer: "top", width: 600, height: 600 },
+  )
+
+  expect(svg).toContain('class="pcb-solder-paste"')
+  expect(svg).toContain('data-pcb-smtpad-id="polygon_pad"')
+  expect(svg).toContain('points="260,340 340,340 340,260 260,260"')
+})


### PR DESCRIPTION
## Summary

- synthesize solder paste SVG geometry from `pcb_smtpad.solderpaste_margin` when linked explicit paste is absent
- apply the fallback in both solder-paste-mask exports and PCB SVGs using `showSolderPaste`
- support every SMT pad shape, including offset polygon apertures
- consume the released `PcbSmtPad.solderpaste_margin` type directly

Uses `circuit-json@^0.0.463`; the schema landed in tscircuit/circuit-json#682.

## Testing

- `bun test` (298 pass, 0 fail)
- `bunx tsc --noEmit`
- `bun run build`