### PR TITLE
fix(pcb): fall back to finite bounds when a circuit has no PCB elements

### DIFF
--- a/lib/pcb/convert-circuit-json-to-pcb-svg.ts
+++ b/lib/pcb/convert-circuit-json-to-pcb-svg.ts
@@ -216,17 +216,31 @@ export function convertCircuitJsonToPcbSvg(
     ? circuitJson
     : circuitJson.filter((element) => element.type !== "pcb_courtyard_rect")
 
-  const {
-    minX,
-    minY,
-    maxX,
-    maxY,
-    boardMinX,
-    boardMinY,
-    boardMaxX,
-    boardMaxY,
-    hasBoardBounds,
-  } = getComprehensivePcbBounds(circuitJsonForBounds)
+  const pcbBounds = getComprehensivePcbBounds(circuitJsonForBounds)
+  const { boardMinX, boardMinY, boardMaxX, boardMaxY, hasBoardBounds } =
+    pcbBounds
+
+  // getComprehensivePcbBounds returns non-finite bounds (Infinity) when nothing
+  // contributes PCB bounds. That happens for an empty circuit or for one that
+  // only has source/schematic elements (a schematic-only design or circuit JSON
+  // captured before PCB layout). Those infinities flow into the scale/translate
+  // transform below and turn every projected coordinate into NaN, so the SVG
+  // ends up with an invalid pcb-boundary rect whose x/y/width/height are "NaN".
+  // Fall back to a small finite box the way getSchematicBoundsFromCircuitJson
+  // does for the empty schematic so the PCB SVG stays valid.
+  let { minX, minY, maxX, maxY } = pcbBounds
+  if (
+    !pcbBounds.hasBounds ||
+    !Number.isFinite(minX) ||
+    !Number.isFinite(minY) ||
+    !Number.isFinite(maxX) ||
+    !Number.isFinite(maxY)
+  ) {
+    minX = -1
+    minY = -1
+    maxX = 1
+    maxY = 1
+  }
 
   const { boundsMinX, boundsMinY, boundsMaxX, boundsMaxY, padding } =
     getViewportBounds({

--- a/tests/pcb/__snapshots__/pcb-empty-circuit-nan-bounds.snap.svg
+++ b/tests/pcb/__snapshots__/pcb-empty-circuit-nan-bounds.snap.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="600"><style></style><rect class="boundary" x="0" y="0" fill="#000" width="800" height="600" data-type="pcb_background" data-pcb-layer="global"/><rect class="pcb-boundary" fill="none" stroke="#fff" stroke-width="0.3" x="250" y="150" width="300" height="300" data-type="pcb_boundary" data-pcb-layer="global"/></svg>

--- a/tests/pcb/pcb-empty-circuit-nan-bounds.test.ts
+++ b/tests/pcb/pcb-empty-circuit-nan-bounds.test.ts
@@ -1,0 +1,68 @@
+import { test, expect } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { any_circuit_element } from "circuit-json"
+import { convertCircuitJsonToPcbSvg } from "lib"
+import { getComprehensivePcbBounds } from "lib/pcb/get-pcb-bounds-from-circuit-json"
+
+// Regression: when a circuit has no elements that contribute PCB bounds,
+// getComprehensivePcbBounds returns +/-Infinity with hasBounds:false. The
+// converter ignored that flag and fed the infinities into its scale/translate
+// transform, so every projected coordinate became NaN and the emitted SVG
+// contained `<rect class="pcb-boundary" x="NaN" y="NaN" width="NaN"
+// height="NaN" ...>`, which is not valid SVG. This happens on two valid inputs:
+//   1. an empty circuit `[]`
+//   2. a circuit that only has source/schematic elements (a schematic-only
+//      design or circuit JSON captured before PCB layout)
+// The schematic converter already falls back to a finite default box for the
+// empty case; the PCB converter now does the same.
+
+// A schematic-only circuit: valid circuit-json, but nothing on the PCB.
+const schematicOnly: AnyCircuitElement[] = [
+  {
+    type: "source_component",
+    source_component_id: "sc1",
+    name: "R1",
+    ftype: "simple_resistor",
+    resistance: 1000,
+  },
+  {
+    type: "schematic_component",
+    schematic_component_id: "sch1",
+    source_component_id: "sc1",
+    center: { x: 0, y: 0 },
+    size: { width: 1, height: 0.4 },
+    rotation: 0,
+  },
+] as AnyCircuitElement[]
+
+test("empty and schematic-only inputs are valid circuit-json with no PCB bounds", () => {
+  // Prove the inputs are schema-valid so the NaN is the renderer's fault.
+  for (const element of schematicOnly) {
+    expect(() => any_circuit_element.parse(element)).not.toThrow()
+  }
+  expect(getComprehensivePcbBounds([]).hasBounds).toBe(false)
+  expect(getComprehensivePcbBounds(schematicOnly).hasBounds).toBe(false)
+})
+
+test("convertCircuitJsonToPcbSvg([]) does not emit NaN coordinates", () => {
+  const svg = convertCircuitJsonToPcbSvg([])
+  expect(svg).not.toContain("NaN")
+  expect(svg).not.toContain("Infinity")
+  expect(svg).toContain("<svg")
+})
+
+test("schematic-only circuit renders valid PCB SVG instead of NaN", () => {
+  const svg = convertCircuitJsonToPcbSvg(schematicOnly)
+  expect(svg).not.toContain("NaN")
+  expect(svg).not.toContain("Infinity")
+
+  // The boundary rect is where the NaN surfaced; confirm it is finite now.
+  const boundary = svg.match(/<rect class="pcb-boundary"[^>]*>/)?.[0] ?? ""
+  expect(boundary).not.toBe("")
+  for (const attr of ["x", "y", "width", "height"] as const) {
+    const value = boundary.match(new RegExp(`${attr}="([^"]*)"`))?.[1]
+    expect(Number.isFinite(Number(value))).toBe(true)
+  }
+
+  expect(svg).toMatchSvgSnapshot(import.meta.path)
+})


### PR DESCRIPTION
Fixes #661.

### Problem

`convertCircuitJsonToPcbSvg` emits an invalid `<rect class="pcb-boundary">` with
`x="NaN" y="NaN" width="NaN" height="NaN"` when the circuit has no elements that
contribute PCB bounds. Two valid inputs hit this:

1. an empty circuit `[]`
2. a circuit that only has source/schematic elements (a schematic-only design,
   or circuit JSON captured before PCB layout)

`getComprehensivePcbBounds` returns non-finite bounds (`Infinity`) with
`hasBounds: false` for these. The converter fed those infinities straight into
its scale/translate transform. `circuitWidth * scaleFactor` works out to
`Infinity * 0 = NaN`, so every projected coordinate became `NaN`.

### Fix

Honor the `hasBounds` flag the bounds function already returns. When bounds are
absent or non-finite, fall back to a small finite box before building the
transform. This mirrors `getSchematicBoundsFromCircuitJson`, which already does
`if (!Number.isFinite(minX)) { minX = -1; maxX = 1 }` so an empty schematic
renders a valid SVG. Circuits that do have PCB bounds are unaffected: the guard
only runs when the transform would otherwise be non-finite.

Scope is limited to this no-bounds case. Non-finite and negative field values on
individual elements (#634, #636, #638, #640) are separate and left alone.

### Tests

`tests/pcb/pcb-empty-circuit-nan-bounds.test.ts`:

- asserts the empty and schematic-only inputs are valid circuit-json (each parses
  against `any_circuit_element`) and that `getComprehensivePcbBounds` reports
  `hasBounds: false` for them
- `convertCircuitJsonToPcbSvg([])` contains no `NaN` or `Infinity`
- the schematic-only circuit renders a `pcb-boundary` rect with finite
  `x`/`y`/`width`/`height`, plus an SVG snapshot of the now-valid output

Verified the two render assertions fail on `main` (the output has `x="NaN"`) and
pass with this change. Full `bun test` is 308 pass / 1 fail, where the single
failure is the pre-existing font-dependent `pcb-pad-trace-clearance-error` image
snapshot that also fails on `main` and is unrelated to this change. No other
committed snapshot changed. `bunx tsc --noEmit` clean and `biome format` clean on
the touched files.

---

AI assistance (Claude, Anthropic) was used in developing this change. The design,
review and verification were done by the author. Verified locally before
submitting: `bun test` (308 pass, 1 pre-existing unrelated flaky fail),
`bunx tsc --noEmit` and `biome format` on the changed files.
