### PR TITLE
fix(svg): normalize negative dimensions to positive lengths for PCB and schematic elements

### DIFF
--- a/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-hole.ts
+++ b/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-hole.ts
@@ -25,7 +25,7 @@ export function createSvgObjectsFromPcbHole(
   const solderMaskColor = colorMap.soldermask.top
 
   if (hole.hole_shape === "circle" || hole.hole_shape === "square") {
-    const scaledDiameter = hole.hole_diameter * Math.abs(transform.a)
+    const scaledDiameter = Math.abs(hole.hole_diameter * transform.a)
     const radius = scaledDiameter / 2
 
     if (hole.hole_shape === "circle") {

--- a/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-keepout.ts
+++ b/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-keepout.ts
@@ -131,8 +131,8 @@ export function createSvgObjectsFromPcbKeepout(
         rectKeepout.center.x,
         rectKeepout.center.y,
       ])
-      const scaledWidth = rectKeepout.width * Math.abs(transform.a)
-      const scaledHeight = rectKeepout.height * Math.abs(transform.d)
+      const scaledWidth = Math.abs(rectKeepout.width * transform.a)
+      const scaledHeight = Math.abs(rectKeepout.height * transform.d)
       const baseTransform = matrixToString(compose(translate(cx, cy)))
 
       const backgroundAttributes = {
@@ -186,7 +186,7 @@ export function createSvgObjectsFromPcbKeepout(
         circleKeepout.center.x,
         circleKeepout.center.y,
       ])
-      const scaledRadius = circleKeepout.radius * Math.abs(transform.a)
+      const scaledRadius = Math.abs(circleKeepout.radius * transform.a)
 
       const backgroundAttributes = {
         ...createKeepoutBaseAttributes(

--- a/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-via.ts
+++ b/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-via.ts
@@ -5,10 +5,10 @@ import type { PcbContext } from "../convert-circuit-json-to-pcb-svg"
 export function createSvgObjectsFromPcbVia(hole: PCBVia, ctx: PcbContext): any {
   const { transform, colorMap } = ctx
   const [x, y] = applyToPoint(transform, [hole.x, hole.y])
-  const scaledOuterWidth = hole.outer_diameter * Math.abs(transform.a)
-  const scaledOuterHeight = hole.outer_diameter * Math.abs(transform.a)
-  const scaledHoleWidth = hole.hole_diameter * Math.abs(transform.a)
-  const scaledHoleHeight = hole.hole_diameter * Math.abs(transform.a)
+  const scaledOuterWidth = Math.abs(hole.outer_diameter * transform.a)
+  const scaledOuterHeight = Math.abs(hole.outer_diameter * transform.a)
+  const scaledHoleWidth = Math.abs(hole.hole_diameter * transform.a)
+  const scaledHoleHeight = Math.abs(hole.hole_diameter * transform.a)
 
   const outerRadius = Math.min(scaledOuterWidth, scaledOuterHeight) / 2
   const innerRadius = Math.min(scaledHoleWidth, scaledHoleHeight) / 2

--- a/lib/sch/svg-object-fns/create-svg-objects-from-sch-component-with-box.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-from-sch-component-with-box.ts
@@ -29,18 +29,24 @@ export const createSvgObjectsFromSchematicComponentWithBox = ({
 }): SvgObject[] => {
   const svgObjects: SvgObject[] = []
 
-  const componentScreenTopLeft = applyToPoint(transform, {
-    x: schComponent.center.x - schComponent.size.width / 2,
-    y: schComponent.center.y + schComponent.size.height / 2,
+  const halfWidth = Math.abs(schComponent.size.width) / 2
+  const halfHeight = Math.abs(schComponent.size.height) / 2
+
+  const p1 = applyToPoint(transform, {
+    x: schComponent.center.x - halfWidth,
+    y: schComponent.center.y + halfHeight,
   })
-  const componentScreenBottomRight = applyToPoint(transform, {
-    x: schComponent.center.x + schComponent.size.width / 2,
-    y: schComponent.center.y - schComponent.size.height / 2,
+  const p2 = applyToPoint(transform, {
+    x: schComponent.center.x + halfWidth,
+    y: schComponent.center.y - halfHeight,
   })
-  const componentScreenWidth =
-    componentScreenBottomRight.x - componentScreenTopLeft.x
-  const componentScreenHeight =
-    componentScreenBottomRight.y - componentScreenTopLeft.y
+
+  const componentScreenTopLeft = {
+    x: Math.min(p1.x, p2.x),
+    y: Math.min(p1.y, p2.y),
+  }
+  const componentScreenWidth = Math.abs(p2.x - p1.x)
+  const componentScreenHeight = Math.abs(p2.y - p1.y)
 
   // Add basic rectangle for component body
   svgObjects.push({

--- a/tests/pcb/negative-dimensions.test.ts
+++ b/tests/pcb/negative-dimensions.test.ts
@@ -65,6 +65,7 @@ test("negative dimensions emit positive SVG lengths for schematic components (#6
       source_component_id: "chip1",
       center: { x: 0, y: 0 },
       size: { width: -4, height: -3 },
+      is_box_with_pins: true,
     },
   ]
 

--- a/tests/pcb/negative-dimensions.test.ts
+++ b/tests/pcb/negative-dimensions.test.ts
@@ -1,0 +1,76 @@
+import { test, expect } from "bun:test"
+import { convertCircuitJsonToPcbSvg } from "lib/pcb/convert-circuit-json-to-pcb-svg"
+import { convertCircuitJsonToSchematicSvg } from "lib/sch/convert-circuit-json-to-schematic-svg"
+import type { AnyCircuitElement } from "circuit-json"
+
+test("negative dimensions emit positive SVG lengths for PCB elements (#640)", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "pcb_board",
+      pcb_board_id: "board1",
+      center: { x: 0, y: 0 },
+      width: 20,
+      height: 20,
+      thickness: 1.6,
+      num_layers: 2,
+    },
+    {
+      type: "pcb_via",
+      pcb_via_id: "via1",
+      x: 3,
+      y: 3,
+      hole_diameter: -1,
+      outer_diameter: -2,
+      layers: ["top", "bottom"],
+    },
+    {
+      type: "pcb_hole",
+      pcb_hole_id: "hole1",
+      hole_shape: "circle",
+      x: -3,
+      y: -3,
+      hole_diameter: -2,
+    },
+    {
+      type: "pcb_keepout",
+      pcb_keepout_id: "keepout1",
+      shape: "circle",
+      center: { x: 0, y: 0 },
+      radius: -1.5,
+      layers: ["top"],
+    },
+  ]
+
+  const svg = convertCircuitJsonToPcbSvg(circuitJson)
+
+  // Verify no negative radius or width attributes exist
+  expect(svg).not.toMatch(/r="-[0-9.]+/)
+  expect(svg).not.toMatch(/width="-[0-9.]+/)
+  expect(svg).not.toMatch(/height="-[0-9.]+/)
+  expect(svg).toContain('class="pcb-hole-outer"')
+  expect(svg).toContain('class="pcb-hole-inner"')
+})
+
+test("negative dimensions emit positive SVG lengths for schematic components (#640)", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      source_component_id: "chip1",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "schematic_component",
+      schematic_component_id: "sch_chip1",
+      source_component_id: "chip1",
+      center: { x: 0, y: 0 },
+      size: { width: -4, height: -3 },
+    },
+  ]
+
+  const svg = convertCircuitJsonToSchematicSvg(circuitJson)
+
+  expect(svg).not.toMatch(/width="-[0-9.]+/)
+  expect(svg).not.toMatch(/height="-[0-9.]+/)
+  expect(svg).toContain('class="component chip sch-component-body"')
+})


### PR DESCRIPTION
## Summary

Fixes #640.

Previously, negative dimensions (e.g. from input data or component size specs) were emitted directly into SVG attributes like \`r\`, \`width\`, or \`height\`. Per SVG specifications, negative geometric lengths are invalid and cause SVG renderers to drop the shape entirely rather than drawing the element.

### Changes
1. **PCB Via & Hole Sanitization**: Applied \`Math.abs\` to scaled outer/inner diameters in \`createSvgObjectsFromPcbVia\` and \`createSvgObjectsFromPcbHole\`.
2. **PCB Keepouts**: Constrained \`scaledWidth\`, \`scaledHeight\`, and \`scaledRadius\` to positive lengths in \`createSvgObjectsFromPcbKeepout\`.
3. **Schematic Box Components**: Calculated top-left and bottom-right box corner points from absolute size dimensions in \`createSvgObjectsFromSchematicComponentWithBox\`.
4. **Unit Tests**: Added \`tests/pcb/negative-dimensions.test.ts\` verifying that negative inputs for vias, holes, keepouts, and schematic chips produce well-formed positive SVG lengths.

### Verification
- \`bun test tests/pcb/negative-dimensions.test.ts\` (2/2 passing).
