### PR TITLE
fix(sch): safeguard against non-finite schematic component size and center coordinates

### DIFF
--- a/lib/sch/svg-object-fns/create-svg-objects-from-sch-component-with-box.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-from-sch-component-with-box.ts
@@ -29,18 +29,46 @@ export const createSvgObjectsFromSchematicComponentWithBox = ({
 }): SvgObject[] => {
   const svgObjects: SvgObject[] = []
 
-  const componentScreenTopLeft = applyToPoint(transform, {
-    x: schComponent.center.x - schComponent.size.width / 2,
-    y: schComponent.center.y + schComponent.size.height / 2,
+  const rawWidth = schComponent.size?.width
+  const rawHeight = schComponent.size?.height
+  const safeWidth =
+    typeof rawWidth === "number" && Number.isFinite(rawWidth)
+      ? Math.abs(rawWidth)
+      : 0
+  const safeHeight =
+    typeof rawHeight === "number" && Number.isFinite(rawHeight)
+      ? Math.abs(rawHeight)
+      : 0
+
+  const centerX =
+    typeof schComponent.center?.x === "number" &&
+    Number.isFinite(schComponent.center.x)
+      ? schComponent.center.x
+      : 0
+  const centerY =
+    typeof schComponent.center?.y === "number" &&
+    Number.isFinite(schComponent.center.y)
+      ? schComponent.center.y
+      : 0
+
+  const halfWidth = safeWidth / 2
+  const halfHeight = safeHeight / 2
+
+  const p1 = applyToPoint(transform, {
+    x: centerX - halfWidth,
+    y: centerY + halfHeight,
   })
-  const componentScreenBottomRight = applyToPoint(transform, {
-    x: schComponent.center.x + schComponent.size.width / 2,
-    y: schComponent.center.y - schComponent.size.height / 2,
+  const p2 = applyToPoint(transform, {
+    x: centerX + halfWidth,
+    y: centerY - halfHeight,
   })
-  const componentScreenWidth =
-    componentScreenBottomRight.x - componentScreenTopLeft.x
-  const componentScreenHeight =
-    componentScreenBottomRight.y - componentScreenTopLeft.y
+
+  const componentScreenTopLeft = {
+    x: Math.min(p1.x, p2.x),
+    y: Math.min(p1.y, p2.y),
+  }
+  const componentScreenWidth = Math.abs(p2.x - p1.x)
+  const componentScreenHeight = Math.abs(p2.y - p1.y)
 
   // Add basic rectangle for component body
   svgObjects.push({

--- a/tests/sch/non-finite-component-size.test.ts
+++ b/tests/sch/non-finite-component-size.test.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "bun:test"
+import { convertCircuitJsonToSchematicSvg } from "lib/sch/convert-circuit-json-to-schematic-svg"
+import type { AnyCircuitElement } from "circuit-json"
+
+test("non-finite schematic component size renders well-formed SVG without NaN (#638)", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      source_component_id: "chip1",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "schematic_component",
+      schematic_component_id: "sch_chip1",
+      source_component_id: "chip1",
+      center: { x: 0, y: 0 },
+      size: { width: Number.NaN, height: Number.NaN },
+    },
+  ]
+
+  const svg = convertCircuitJsonToSchematicSvg(circuitJson)
+
+  expect(svg).not.toContain("NaN")
+  expect(svg).toContain('class="component chip sch-component-body"')
+  expect(svg).toContain('class="component-overlay sch-component-overlay"')
+})

--- a/tests/sch/non-finite-component-size.test.ts
+++ b/tests/sch/non-finite-component-size.test.ts
@@ -16,6 +16,7 @@ test("non-finite schematic component size renders well-formed SVG without NaN (#
       source_component_id: "chip1",
       center: { x: 0, y: 0 },
       size: { width: Number.NaN, height: Number.NaN },
+      is_box_with_pins: true,
     },
   ]
 


### PR DESCRIPTION
## Summary

Fixes #638.

Previously, if a \`schematic_component\` had non-finite \`size.width\`, \`size.height\`, or center coordinates (e.g. from an unparseable prop like \`schWidth="abc"\` reaching the renderer as \`NaN\`), \`createSvgObjectsFromSchematicComponentWithBox\` derived screen coordinates using \`NaN / 2\`. This propagated \`NaN\` across \`x\`, \`y\`, \`width\`, and \`height\`, causing SVG renderers to drop the component body.

### Changes
1. **Dimension Sanitization**: Handled non-finite and missing \`size.width\` and \`size.height\` by falling back safely to \`0\`.
2. **Center Coordinate Fallback**: Guaranteed \`centerX\` and \`centerY\` are finite numbers.
3. **Unit Tests**: Added \`tests/sch/non-finite-component-size.test.ts\` verifying components with \`NaN\` sizes render without producing \`NaN\` SVG attributes.

### Verification
- \`bun test tests/sch/non-finite-component-size.test.ts\` (1/1 passing).
