### PR TITLE
fix(pcb): safeguard against non-finite via and plated-hole diameters

### DIFF
--- a/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-plated-hole.ts
+++ b/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-plated-hole.ts
@@ -269,10 +269,21 @@ export function createSvgObjectsFromPcbPlatedHole(
   }
   // Fallback to circular hole if not pill-shaped
   if (hole.shape === "circle") {
-    const scaledOuterWidth = hole.outer_diameter * Math.abs(transform.a)
-    const scaledOuterHeight = hole.outer_diameter * Math.abs(transform.a)
-    const scaledHoleWidth = hole.hole_diameter * Math.abs(transform.a)
-    const scaledHoleHeight = hole.hole_diameter * Math.abs(transform.a)
+    const rawOuter = hole.outer_diameter
+    const rawInner = hole.hole_diameter
+    const safeOuter =
+      typeof rawOuter === "number" && Number.isFinite(rawOuter)
+        ? Math.abs(rawOuter)
+        : 0
+    const safeInner =
+      typeof rawInner === "number" && Number.isFinite(rawInner)
+        ? Math.abs(rawInner)
+        : 0
+
+    const scaledOuterWidth = safeOuter * Math.abs(transform.a)
+    const scaledOuterHeight = safeOuter * Math.abs(transform.a)
+    const scaledHoleWidth = safeInner * Math.abs(transform.a)
+    const scaledHoleHeight = safeInner * Math.abs(transform.a)
 
     const outerRadius = Math.min(scaledOuterWidth, scaledOuterHeight) / 2
     const innerRadius = Math.min(scaledHoleWidth, scaledHoleHeight) / 2

--- a/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-via.ts
+++ b/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-via.ts
@@ -5,10 +5,21 @@ import type { PcbContext } from "../convert-circuit-json-to-pcb-svg"
 export function createSvgObjectsFromPcbVia(hole: PCBVia, ctx: PcbContext): any {
   const { transform, colorMap } = ctx
   const [x, y] = applyToPoint(transform, [hole.x, hole.y])
-  const scaledOuterWidth = hole.outer_diameter * Math.abs(transform.a)
-  const scaledOuterHeight = hole.outer_diameter * Math.abs(transform.a)
-  const scaledHoleWidth = hole.hole_diameter * Math.abs(transform.a)
-  const scaledHoleHeight = hole.hole_diameter * Math.abs(transform.a)
+  const rawOuter = hole.outer_diameter
+  const rawInner = hole.hole_diameter
+  const safeOuter =
+    typeof rawOuter === "number" && Number.isFinite(rawOuter)
+      ? Math.abs(rawOuter)
+      : 0
+  const safeInner =
+    typeof rawInner === "number" && Number.isFinite(rawInner)
+      ? Math.abs(rawInner)
+      : 0
+
+  const scaledOuterWidth = safeOuter * Math.abs(transform.a)
+  const scaledOuterHeight = safeOuter * Math.abs(transform.a)
+  const scaledHoleWidth = safeInner * Math.abs(transform.a)
+  const scaledHoleHeight = safeInner * Math.abs(transform.a)
 
   const outerRadius = Math.min(scaledOuterWidth, scaledOuterHeight) / 2
   const innerRadius = Math.min(scaledHoleWidth, scaledHoleHeight) / 2

--- a/tests/pcb/non-finite-via-plated-hole.test.ts
+++ b/tests/pcb/non-finite-via-plated-hole.test.ts
@@ -12,6 +12,7 @@ test("non-finite via and plated-hole diameters render without NaN (#634)", () =>
       height: 20,
       thickness: 1.6,
       num_layers: 2,
+      material: "fr4",
     },
     {
       type: "pcb_via",

--- a/tests/pcb/non-finite-via-plated-hole.test.ts
+++ b/tests/pcb/non-finite-via-plated-hole.test.ts
@@ -1,0 +1,43 @@
+import { test, expect } from "bun:test"
+import { convertCircuitJsonToPcbSvg } from "lib/pcb/convert-circuit-json-to-pcb-svg"
+import type { AnyCircuitElement } from "circuit-json"
+
+test("non-finite via and plated-hole diameters render without NaN (#634)", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "pcb_board",
+      pcb_board_id: "board1",
+      center: { x: 0, y: 0 },
+      width: 20,
+      height: 20,
+      thickness: 1.6,
+      num_layers: 2,
+    },
+    {
+      type: "pcb_via",
+      pcb_via_id: "via1",
+      x: 5,
+      y: 5,
+      hole_diameter: Number.NaN,
+      outer_diameter: 0.6,
+      layers: ["top", "bottom"],
+    },
+    {
+      type: "pcb_plated_hole",
+      pcb_plated_hole_id: "ph1",
+      shape: "circle",
+      x: -5,
+      y: -5,
+      hole_diameter: Number.NaN,
+      outer_diameter: 1.0,
+      layers: ["top", "bottom"],
+    },
+  ]
+
+  const svg = convertCircuitJsonToPcbSvg(circuitJson)
+
+  expect(svg).not.toContain("NaN")
+  expect(svg).toContain('class="pcb-hole-inner"')
+  expect(svg).toContain('data-type="pcb_via"')
+  expect(svg).toContain('data-type="pcb_plated_hole_drill"')
+})


### PR DESCRIPTION
## Summary

Fixes #634.

Previously, if a via or plated hole had a non-finite diameter (e.g. from an unparseable unit string reaching the renderer as \`NaN\`), multiplying and dividing to obtain \`innerRadius\` produced \`NaN\`. This emitted \`r="NaN"\`, causing SVG renderers to drop the drill hole entirely.

### Changes
1. **PCB Via Sanitization**: Checked \`Number.isFinite\` on \`hole.outer_diameter\` and \`hole.hole_diameter\`, falling back non-finite values safely to \`0\`.
2. **PCB Plated Hole Sanitization**: Handled non-finite values for circular plated hole \`outer_diameter\` and \`hole_diameter\` by falling back safely to \`0\`.
3. **Unit Tests**: Added \`tests/pcb/non-finite-via-plated-hole.test.ts\` verifying that vias and plated holes with \`NaN\` diameters render valid SVG without \`NaN\` attributes.

### Verification
- \`bun test tests/pcb/non-finite-via-plated-hole.test.ts\` (1/1 passing).
