### PR TITLE
fix(sch): preserve path fill in schematic symbol rendering and guard bounds calculation

### DIFF
--- a/lib/sch/get-schematic-bounds-from-circuit-json.ts
+++ b/lib/sch/get-schematic-bounds-from-circuit-json.ts
@@ -224,6 +224,16 @@ export function getSchematicBoundsFromCircuitJson(
   return { minX, minY, maxX, maxY }
 
   function updateBounds(center: any, size: any, rotation: number) {
+    if (
+      !center ||
+      !size ||
+      typeof size.width !== "number" ||
+      typeof size.height !== "number" ||
+      !Number.isFinite(size.width) ||
+      !Number.isFinite(size.height)
+    ) {
+      return
+    }
     const corners = [
       { x: -size.width / 2, y: -size.height / 2 },
       { x: size.width / 2, y: -size.height / 2 },

--- a/lib/sch/svg-object-fns/create-svg-objects-from-sch-component-with-symbol.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-from-sch-component-with-symbol.ts
@@ -171,7 +171,7 @@ export const createSvgObjectsFromSchematicComponentWithSymbol = ({
             })
             .join(" ") + (closed ? " Z" : ""),
         stroke: colorMap.schematic.component_outline,
-        fill: "none",
+        fill: fill ? colorMap.schematic.component_outline : "none",
         "stroke-width": `${getSchStrokeSize(realToScreenTransform)}px`,
         "stroke-linecap": "round",
       },

--- a/tests/sch/gunn-diode-symbol-fill.test.ts
+++ b/tests/sch/gunn-diode-symbol-fill.test.ts
@@ -1,0 +1,57 @@
+import { test, expect } from "bun:test"
+import { convertCircuitJsonToSchematicSvg } from "lib/sch/convert-circuit-json-to-schematic-svg"
+import type { AnyCircuitElement } from "circuit-json"
+
+test("schematic symbols with filled paths preserve path fill (#418)", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      source_component_id: "diode1",
+      name: "D1",
+      ftype: "simple_diode",
+    },
+    {
+      type: "source_port",
+      source_port_id: "port_1",
+      source_component_id: "diode1",
+      name: "1",
+      pin_number: 1,
+    },
+    {
+      type: "source_port",
+      source_port_id: "port_2",
+      source_component_id: "diode1",
+      name: "2",
+      pin_number: 2,
+    },
+    {
+      type: "schematic_component",
+      schematic_component_id: "sch_diode1",
+      source_component_id: "diode1",
+      center: { x: 0, y: 0 },
+      size: { width: 1.2, height: 0.8 },
+      symbol_name: "gunn_diode_horz",
+    },
+    {
+      type: "schematic_port",
+      schematic_port_id: "sch_port_1",
+      source_port_id: "port_1",
+      schematic_component_id: "sch_diode1",
+      center: { x: -0.52, y: 0 },
+      facing_direction: "left",
+    },
+    {
+      type: "schematic_port",
+      schematic_port_id: "sch_port_2",
+      source_port_id: "port_2",
+      schematic_component_id: "sch_diode1",
+      center: { x: 0.52, y: 0 },
+      facing_direction: "right",
+    },
+  ]
+
+  const svg = convertCircuitJsonToSchematicSvg(circuitJson)
+
+  // Verify that paths with fill: true have a color fill rather than all fill="none"
+  expect(svg).toMatch(/class="sch-component-symbol-path"[^>]*fill="(?!none)[^"]+"/)
+})

--- a/tests/sch/gunn-diode-symbol-fill.test.ts
+++ b/tests/sch/gunn-diode-symbol-fill.test.ts
@@ -31,6 +31,7 @@ test("schematic symbols with filled paths preserve path fill (#418)", () => {
       center: { x: 0, y: 0 },
       size: { width: 1.2, height: 0.8 },
       symbol_name: "gunn_diode_horz",
+      is_box_with_pins: true,
     },
     {
       type: "schematic_port",


### PR DESCRIPTION
## Summary

Previously, \`createSvgObjectsFromSchematicComponentWithSymbol\` hardcoded \`fill: "none"\` across all symbol paths, ignoring \`path.fill\`. As a result, schematic symbols with filled polygons (such as Gunn diodes, diodes, and rectifiers) had their filled elements rendered as empty outlines.

### Changes
1. **Symbol Path Fill**: Set \`fill: fill ? colorMap.schematic.component_outline : "none"\` on symbol path SVG elements.
2. **Bounds Calculation Guard**: Guarded \`updateBounds\` in \`getSchematicBoundsFromCircuitJson\` against missing or non-finite \`size\` and \`center\` definitions.
3. **Unit Tests**: Added \`tests/sch/gunn-diode-symbol-fill.test.ts\` verifying that components with filled symbol paths preserve color fills in the emitted SVG.

### Verification
- \`bun test tests/sch/gunn-diode-symbol-fill.test.ts\` (1/1 passing).
