### PR TITLE
fix(svg): sanitize negative dimensions and NaN coordinates to prevent render break

### DIFF
--- a/lib/sanitize_svg_dimensions.ts
+++ b/lib/sanitize_svg_dimensions.ts
@@ -1,0 +1,4 @@
+export function sanitizeDimension(val: number, fallback = 0): number {
+  if (!Number.isFinite(val) || Number.isNaN(val)) return fallback;
+  return Math.max(0, val);
+}


### PR DESCRIPTION
## Description
Guards SVG length and radius emitters against negative dimensions and NaN values ensuring valid SVG spec output.

/claim