### PR TITLE
Expose schematic text identity in SVG

### DIFF
--- a/lib/sch/svg-object-fns/create-svg-objects-for-sch-text.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-for-sch-text.ts
@@ -2,7 +2,7 @@ import type { SchematicText } from "circuit-json"
 import type { SvgObject } from "lib/svg-object"
 import type { ColorMap } from "lib/utils/colors"
 import { getSchScreenFontSize } from "lib/utils/get-sch-font-size"
-import { applyToPoint, type Matrix } from "transformation-matrix"
+import { type Matrix, applyToPoint } from "transformation-matrix"
 
 export const createSvgSchText = ({
   elm,
@@ -79,8 +79,6 @@ export const createSvgSchText = ({
   }
 
   const lines = elm.text.split("\n")
-  const classNames = ["sch-text"]
-  if (elm.source_trace_id) classNames.push("sch-inline-net-label")
 
   const children: SvgObject[] =
     lines.length === 1
@@ -117,12 +115,9 @@ export const createSvgSchText = ({
     name: "text",
     value: "",
     attributes: {
-      class: classNames.join(" "),
+      class: "sch-text",
       "data-circuit-json-type": "schematic_text",
       "data-schematic-text-id": elm.schematic_text_id,
-      ...(elm.source_trace_id && {
-        "data-source-trace-id": elm.source_trace_id,
-      }),
       x: center.x.toString(),
       y: center.y.toString(),
       fill: elm.color ?? colorMap.schematic.sheet_label,

--- a/lib/sch/svg-object-fns/create-svg-objects-for-sch-text.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-for-sch-text.ts
@@ -79,6 +79,8 @@ export const createSvgSchText = ({
   }
 
   const lines = elm.text.split("\n")
+  const classNames = ["sch-text"]
+  if (elm.source_trace_id) classNames.push("sch-inline-net-label")
 
   const children: SvgObject[] =
     lines.length === 1
@@ -115,7 +117,12 @@ export const createSvgSchText = ({
     name: "text",
     value: "",
     attributes: {
-      class: "sch-text",
+      class: classNames.join(" "),
+      "data-circuit-json-type": "schematic_text",
+      "data-schematic-text-id": elm.schematic_text_id,
+      ...(elm.source_trace_id && {
+        "data-source-trace-id": elm.source_trace_id,
+      }),
       x: center.x.toString(),
       y: center.y.toString(),
       fill: elm.color ?? colorMap.schematic.sheet_label,

--- a/tests/sch/schematic-inline-net-label-metadata.test.ts
+++ b/tests/sch/schematic-inline-net-label-metadata.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "bun:test"
+import type { SchematicText } from "circuit-json"
+import { convertCircuitJsonToSchematicSvg } from "lib"
+
+test("inline net label text includes source trace metadata", () => {
+  const circuitJson: SchematicText[] = [
+    {
+      type: "schematic_text",
+      schematic_text_id: "schematic_text_inline_label",
+      source_trace_id: "source_trace_signal",
+      text: "SIGNAL",
+      position: { x: 0, y: 0 },
+      anchor: "center",
+      rotation: 0,
+      font_size: 0.2,
+      color: "rgb(132, 0, 0)",
+    },
+    {
+      type: "schematic_text",
+      schematic_text_id: "schematic_text_note",
+      text: "note",
+      position: { x: 0, y: 1 },
+      anchor: "center",
+      rotation: 0,
+      font_size: 0.2,
+      color: "#006464",
+    },
+  ]
+
+  const svg = convertCircuitJsonToSchematicSvg(circuitJson)
+
+  expect(svg).toContain(
+    'class="sch-text sch-inline-net-label" data-circuit-json-type="schematic_text" data-schematic-text-id="schematic_text_inline_label" data-source-trace-id="source_trace_signal"',
+  )
+  expect(svg).toContain(
+    'class="sch-text" data-circuit-json-type="schematic_text" data-schematic-text-id="schematic_text_note"',
+  )
+  expect(svg).not.toContain(
+    'data-schematic-text-id="schematic_text_note" data-source-trace-id',
+  )
+})

--- a/tests/sch/schematic-inline-net-label-metadata.test.ts
+++ b/tests/sch/schematic-inline-net-label-metadata.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test"
 import type { SchematicText } from "circuit-json"
 import { convertCircuitJsonToSchematicSvg } from "lib"
 
-test("inline net label text includes source trace metadata", () => {
+test("schematic text includes its circuit json identity", () => {
   const circuitJson: SchematicText[] = [
     {
       type: "schematic_text",
@@ -30,12 +30,10 @@ test("inline net label text includes source trace metadata", () => {
   const svg = convertCircuitJsonToSchematicSvg(circuitJson)
 
   expect(svg).toContain(
-    'class="sch-text sch-inline-net-label" data-circuit-json-type="schematic_text" data-schematic-text-id="schematic_text_inline_label" data-source-trace-id="source_trace_signal"',
+    'class="sch-text" data-circuit-json-type="schematic_text" data-schematic-text-id="schematic_text_inline_label"',
   )
   expect(svg).toContain(
     'class="sch-text" data-circuit-json-type="schematic_text" data-schematic-text-id="schematic_text_note"',
   )
-  expect(svg).not.toContain(
-    'data-schematic-text-id="schematic_text_note" data-source-trace-id',
-  )
+  expect(svg).not.toContain("data-source-trace-id")
 })


### PR DESCRIPTION
### Motivation
- Expose schematic text IDs in SVG so [schematic-viewer#265](https://github.com/tscircuit/schematic-viewer/pull/265) can support inline net-label hover.