### PR TITLE
Fix non-finite via and plated-hole diameters emitting r="NaN"

### DIFF
--- a/lib/assembly/svg-object-fns/create-svg-objects-from-assembly-plated-hole.ts
+++ b/lib/assembly/svg-object-fns/create-svg-objects-from-assembly-plated-hole.ts
@@ -81,10 +81,18 @@ export function createSvgObjectsFromAssemblyPlatedHole(
 
   // Fallback to circular hole if not pill-shaped
   if (hole.shape === "circle") {
-    const scaledOuterWidth = hole.outer_diameter * Math.abs(transform.a)
-    const scaledOuterHeight = hole.outer_diameter * Math.abs(transform.a)
-    const scaledHoleWidth = hole.hole_diameter * Math.abs(transform.a)
-    const scaledHoleHeight = hole.hole_diameter * Math.abs(transform.a)
+    const scaledOuterWidth =
+      (Number.isFinite(hole.outer_diameter) ? hole.outer_diameter : 0) *
+      Math.abs(transform.a)
+    const scaledOuterHeight =
+      (Number.isFinite(hole.outer_diameter) ? hole.outer_diameter : 0) *
+      Math.abs(transform.a)
+    const scaledHoleWidth =
+      (Number.isFinite(hole.hole_diameter) ? hole.hole_diameter : 0) *
+      Math.abs(transform.a)
+    const scaledHoleHeight =
+      (Number.isFinite(hole.hole_diameter) ? hole.hole_diameter : 0) *
+      Math.abs(transform.a)
 
     const outerRadius = Math.min(scaledOuterWidth, scaledOuterHeight) / 2
     const innerRadius = Math.min(scaledHoleWidth, scaledHoleHeight) / 2
@@ -130,7 +138,9 @@ export function createSvgObjectsFromAssemblyPlatedHole(
   if (hole.shape === "circular_hole_with_rect_pad") {
     const circularHole = hole as PcbHoleCircularWithRectPad
     const scaledHoleDiameter =
-      circularHole.hole_diameter * Math.abs(transform.a)
+      (Number.isFinite(circularHole.hole_diameter)
+        ? circularHole.hole_diameter
+        : 0) * Math.abs(transform.a)
     const scaledRectPadWidth =
       circularHole.rect_pad_width * Math.abs(transform.a)
     const scaledRectPadHeight =

--- a/lib/pcb/get-pcb-bounds-from-circuit-json.ts
+++ b/lib/pcb/get-pcb-bounds-from-circuit-json.ts
@@ -14,6 +14,16 @@ import {
 } from "./get-pcb-trace-segments"
 import { getTextCenterFromAnchorPosition } from "./get-text-center-from-anchor-position"
 
+function parseOptionalDistance(
+  value: string | number | null | undefined,
+): number | undefined {
+  if (value === null || value === undefined) {
+    return undefined
+  }
+  const result = distance.safeParse(value)
+  return result.success ? result.data : undefined
+}
+
 export interface PcbBounds {
   minX: number
   minY: number
@@ -113,7 +123,7 @@ export function getComprehensivePcbBounds(
         updateTraceBounds(pad.points)
       }
     } else if (circuitJsonElm.type === "pcb_via") {
-      const outerDiameter = distance.parse(circuitJsonElm.outer_diameter)
+      const outerDiameter = parseOptionalDistance(circuitJsonElm.outer_diameter)
       updateBounds({
         center: { x: circuitJsonElm.x, y: circuitJsonElm.y },
         width: outerDiameter ?? 0,
@@ -123,7 +133,7 @@ export function getComprehensivePcbBounds(
       const platedHole = circuitJsonElm
       const holeCenter = { x: platedHole.x, y: platedHole.y }
       if (platedHole.shape === "circle") {
-        const outerDiameter = distance.parse(platedHole.outer_diameter)
+        const outerDiameter = parseOptionalDistance(platedHole.outer_diameter)
         updateBounds({
           center: holeCenter,
           width: outerDiameter ?? 0,
@@ -164,7 +174,7 @@ export function getComprehensivePcbBounds(
       const hole = circuitJsonElm
       const holeCenter = { x: hole.x, y: hole.y }
       if (hole.hole_shape === "circle" || hole.hole_shape === "square") {
-        const diameter = distance.parse(hole.hole_diameter)
+        const diameter = parseOptionalDistance(hole.hole_diameter)
         updateBounds({
           center: holeCenter,
           width: diameter ?? 0,

--- a/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-plated-hole.ts
+++ b/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-plated-hole.ts
@@ -269,10 +269,18 @@ export function createSvgObjectsFromPcbPlatedHole(
   }
   // Fallback to circular hole if not pill-shaped
   if (hole.shape === "circle") {
-    const scaledOuterWidth = hole.outer_diameter * Math.abs(transform.a)
-    const scaledOuterHeight = hole.outer_diameter * Math.abs(transform.a)
-    const scaledHoleWidth = hole.hole_diameter * Math.abs(transform.a)
-    const scaledHoleHeight = hole.hole_diameter * Math.abs(transform.a)
+    const scaledOuterWidth =
+      (Number.isFinite(hole.outer_diameter) ? hole.outer_diameter : 0) *
+      Math.abs(transform.a)
+    const scaledOuterHeight =
+      (Number.isFinite(hole.outer_diameter) ? hole.outer_diameter : 0) *
+      Math.abs(transform.a)
+    const scaledHoleWidth =
+      (Number.isFinite(hole.hole_diameter) ? hole.hole_diameter : 0) *
+      Math.abs(transform.a)
+    const scaledHoleHeight =
+      (Number.isFinite(hole.hole_diameter) ? hole.hole_diameter : 0) *
+      Math.abs(transform.a)
 
     const outerRadius = Math.min(scaledOuterWidth, scaledOuterHeight) / 2
     const innerRadius = Math.min(scaledHoleWidth, scaledHoleHeight) / 2
@@ -392,7 +400,9 @@ export function createSvgObjectsFromPcbPlatedHole(
   // Handle circular hole with rectangular pad (hole is circle, outer pad is rectangle)
   if (hole.shape === "circular_hole_with_rect_pad") {
     const h = hole as PcbHoleCircularWithRectPad
-    const scaledHoleDiameter = hole.hole_diameter * Math.abs(transform.a)
+    const scaledHoleDiameter =
+      (Number.isFinite(hole.hole_diameter) ? hole.hole_diameter : 0) *
+      Math.abs(transform.a)
     const scaledRectPadWidth = hole.rect_pad_width * Math.abs(transform.a)
     const scaledRectPadHeight = hole.rect_pad_height * Math.abs(transform.a)
     const scaledRectBorderRadius =
@@ -958,7 +968,9 @@ export function createSvgObjectsFromPcbPlatedHole(
     const createHoleSvgObject = (): SvgObject => {
       if (polygonHole.hole_shape === "circle") {
         const scaledDiameter =
-          (polygonHole.hole_diameter ?? 0) * Math.abs(transform.a)
+          (Number.isFinite(polygonHole.hole_diameter)
+            ? polygonHole.hole_diameter!
+            : 0) * Math.abs(transform.a)
         const radius = scaledDiameter / 2
         return {
           name: "circle",

--- a/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-via.ts
+++ b/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-via.ts
@@ -5,10 +5,18 @@ import type { PcbContext } from "../convert-circuit-json-to-pcb-svg"
 export function createSvgObjectsFromPcbVia(hole: PCBVia, ctx: PcbContext): any {
   const { transform, colorMap } = ctx
   const [x, y] = applyToPoint(transform, [hole.x, hole.y])
-  const scaledOuterWidth = hole.outer_diameter * Math.abs(transform.a)
-  const scaledOuterHeight = hole.outer_diameter * Math.abs(transform.a)
-  const scaledHoleWidth = hole.hole_diameter * Math.abs(transform.a)
-  const scaledHoleHeight = hole.hole_diameter * Math.abs(transform.a)
+  const scaledOuterWidth =
+    (Number.isFinite(hole.outer_diameter) ? hole.outer_diameter : 0) *
+    Math.abs(transform.a)
+  const scaledOuterHeight =
+    (Number.isFinite(hole.outer_diameter) ? hole.outer_diameter : 0) *
+    Math.abs(transform.a)
+  const scaledHoleWidth =
+    (Number.isFinite(hole.hole_diameter) ? hole.hole_diameter : 0) *
+    Math.abs(transform.a)
+  const scaledHoleHeight =
+    (Number.isFinite(hole.hole_diameter) ? hole.hole_diameter : 0) *
+    Math.abs(transform.a)
 
   const outerRadius = Math.min(scaledOuterWidth, scaledOuterHeight) / 2
   const innerRadius = Math.min(scaledHoleWidth, scaledHoleHeight) / 2

--- a/lib/pinout/svg-object-fns/create-svg-objects-from-pinout-plated-hole.ts
+++ b/lib/pinout/svg-object-fns/create-svg-objects-from-pinout-plated-hole.ts
@@ -73,10 +73,18 @@ export function createSvgObjectsFromPinoutPlatedHole(
 
   // Fallback to circular hole if not pill-shaped
   if (hole.shape === "circle") {
-    const scaledOuterWidth = hole.outer_diameter * Math.abs(transform.a)
-    const scaledOuterHeight = hole.outer_diameter * Math.abs(transform.a)
-    const scaledHoleWidth = hole.hole_diameter * Math.abs(transform.a)
-    const scaledHoleHeight = hole.hole_diameter * Math.abs(transform.a)
+    const scaledOuterWidth =
+      (Number.isFinite(hole.outer_diameter) ? hole.outer_diameter : 0) *
+      Math.abs(transform.a)
+    const scaledOuterHeight =
+      (Number.isFinite(hole.outer_diameter) ? hole.outer_diameter : 0) *
+      Math.abs(transform.a)
+    const scaledHoleWidth =
+      (Number.isFinite(hole.hole_diameter) ? hole.hole_diameter : 0) *
+      Math.abs(transform.a)
+    const scaledHoleHeight =
+      (Number.isFinite(hole.hole_diameter) ? hole.hole_diameter : 0) *
+      Math.abs(transform.a)
 
     const outerRadius = Math.min(scaledOuterWidth, scaledOuterHeight) / 2
     const innerRadius = Math.min(scaledHoleWidth, scaledHoleHeight) / 2
@@ -120,7 +128,9 @@ export function createSvgObjectsFromPinoutPlatedHole(
 
   // Handle circular hole with rectangular pad
   if (hole.shape === "circular_hole_with_rect_pad") {
-    const scaledHoleDiameter = hole.hole_diameter * Math.abs(transform.a)
+    const scaledHoleDiameter =
+      (Number.isFinite(hole.hole_diameter) ? hole.hole_diameter : 0) *
+      Math.abs(transform.a)
     const scaledRectPadWidth = hole.rect_pad_width * Math.abs(transform.a)
     const scaledRectPadHeight = hole.rect_pad_height * Math.abs(transform.a)
 

--- a/tests/pcb/non-finite-diameter.test.ts
+++ b/tests/pcb/non-finite-diameter.test.ts
@@ -1,0 +1,111 @@
+import { test, expect } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToPcbSvg } from "lib"
+
+test('non-finite via hole_diameter and outer_diameter do not emit r="NaN"', () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "pcb_board",
+      pcb_board_id: "board_0",
+      center: { x: 0, y: 0 },
+      width: 20,
+      height: 20,
+      thickness: 1.6,
+      num_layers: 2,
+    } as any,
+    {
+      type: "pcb_via",
+      pcb_via_id: "via_nan_hole",
+      x: 0,
+      y: 0,
+      outer_diameter: 0.6,
+      hole_diameter: Number.NaN,
+      layers: ["top", "bottom"],
+      from_layer: "top",
+      to_layer: "bottom",
+    } as any,
+    {
+      type: "pcb_via",
+      pcb_via_id: "via_nan_outer",
+      x: 5,
+      y: 5,
+      outer_diameter: Number.NaN,
+      hole_diameter: 0.3,
+      layers: ["top", "bottom"],
+      from_layer: "top",
+      to_layer: "bottom",
+    } as any,
+    {
+      type: "pcb_via",
+      pcb_via_id: "via_inf",
+      x: -5,
+      y: -5,
+      outer_diameter: Number.POSITIVE_INFINITY,
+      hole_diameter: Number.NEGATIVE_INFINITY,
+      layers: ["top", "bottom"],
+      from_layer: "top",
+      to_layer: "bottom",
+    } as any,
+  ]
+
+  const svg = convertCircuitJsonToPcbSvg(circuitJson)
+  expect(svg).not.toContain('r="NaN"')
+  expect(svg).not.toContain('r="Infinity"')
+  expect(svg).not.toContain('r="-Infinity"')
+})
+
+test('non-finite plated hole diameters do not emit r="NaN"', () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "pcb_board",
+      pcb_board_id: "board_0",
+      center: { x: 0, y: 0 },
+      width: 20,
+      height: 20,
+      thickness: 1.6,
+      num_layers: 2,
+    } as any,
+    {
+      type: "pcb_plated_hole",
+      pcb_plated_hole_id: "plated_hole_circle_nan",
+      shape: "circle",
+      x: 0,
+      y: 0,
+      outer_diameter: Number.NaN,
+      hole_diameter: Number.NaN,
+      layers: ["top", "bottom"],
+    } as any,
+    {
+      type: "pcb_plated_hole",
+      pcb_plated_hole_id: "plated_hole_circle_rect_pad_nan",
+      shape: "circular_hole_with_rect_pad",
+      x: 5,
+      y: 5,
+      rect_pad_width: 1.5,
+      rect_pad_height: 1.5,
+      hole_diameter: Number.NaN,
+      layers: ["top", "bottom"],
+    } as any,
+    {
+      type: "pcb_plated_hole",
+      pcb_plated_hole_id: "plated_hole_polygon_pad_nan",
+      shape: "hole_with_polygon_pad",
+      hole_shape: "circle",
+      x: -5,
+      y: -5,
+      hole_diameter: Number.NaN,
+      pad_outline: [
+        { x: -1, y: -1 },
+        { x: 1, y: -1 },
+        { x: 1, y: 1 },
+        { x: -1, y: 1 },
+      ],
+      layers: ["top", "bottom"],
+    } as any,
+  ]
+
+  const svg = convertCircuitJsonToPcbSvg(circuitJson)
+  expect(svg).not.toContain('r="NaN"')
+  expect(svg).not.toContain('r="Infinity"')
+  expect(svg).not.toContain('r="-Infinity"')
+})


### PR DESCRIPTION
Fixes #634

### Summary
- Guard against non-finite/NaN `outer_diameter` and `hole_diameter` when computing radius values for PCB vias and plated holes across PCB, Assembly, and Pinout rendering modules.
- Safely parse optional distance values in PCB bounds calculation to prevent Zod errors on non-finite dimensions.
- Added comprehensive tests verifying that non-finite/NaN dimensions do not emit `r="NaN"` attributes.