### PR TITLE
Avoid overlapping PCB debug labels

### DIFF
--- a/lib/pcb/convert-circuit-json-to-pcb-svg.ts
+++ b/lib/pcb/convert-circuit-json-to-pcb-svg.ts
@@ -84,7 +84,11 @@ import { getComprehensivePcbBounds } from "./get-pcb-bounds-from-circuit-json"
 import { getViewportBounds } from "../utils/get-viewport-bounds"
 import { createSvgObjectFromPcbPadPinNumber } from "./svg-object-fns/create-svg-object-from-pcb-pad-pin-number"
 import { createSvgObjectsFromPcbComponentWarning } from "./svg-object-fns/create-svg-objects-from-pcb-component-warning"
-import { createSvgObjectsFromPcbDebugObject } from "./svg-object-fns/create-svg-objects-from-pcb-debug-object"
+import {
+  type PcbDebugObjectLabelLayout,
+  createSvgObjectsFromPcbDebugObject,
+  getPcbDebugObjectLabelLayouts,
+} from "./svg-object-fns/create-svg-objects-from-pcb-debug-object"
 interface PointObjectNotation {
   x: number
   y: number
@@ -147,6 +151,7 @@ export interface PcbContext {
     labelGap: number
     pointRadius: number
   }
+  debugObjectLabelLayouts?: Map<string, PcbDebugObjectLabelLayout>
   showAnchorOffsets?: boolean
   showPinNumbers?: boolean
   circuitJson?: AnyCircuitElement[]
@@ -342,6 +347,16 @@ export function convertCircuitJsonToPcbSvg(
     usedCopperPourTraceMaskIds: new Set<string>(),
   }
 
+  if (ctx.showDebugObjects) {
+    ctx.debugObjectLabelLayouts = getPcbDebugObjectLabelLayouts({
+      debugObjects: circuitJson.filter(
+        (elm) => elm.type === "pcb_debug_object",
+      ),
+      transform,
+      style: ctx.debugObjectStyle!,
+    })
+  }
+
   let unsortedSvgObjects = circuitJson.flatMap((elm) =>
     createSvgObjects({ elm, circuitJson, ctx }),
   )
@@ -499,20 +514,9 @@ function createSvgObjects({
             debugObject: elm,
             transform: ctx.transform,
             style: ctx.debugObjectStyle!,
-            labelStackIndex:
-              elm.shape === "rect"
-                ? circuitJson
-                    .slice(0, circuitJson.indexOf(elm))
-                    .filter(
-                      (other) =>
-                        other.type === "pcb_debug_object" &&
-                        other.shape === "rect" &&
-                        other.center.x === elm.center.x &&
-                        other.center.y === elm.center.y &&
-                        other.size.width === elm.size.width &&
-                        other.size.height === elm.size.height,
-                    ).length
-                : 0,
+            labelLayout: ctx.debugObjectLabelLayouts?.get(
+              elm.pcb_debug_object_id,
+            ),
           })
         : []
     case "pcb_trace_error":

--- a/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-debug-object.ts
+++ b/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-debug-object.ts
@@ -1,6 +1,6 @@
 import type { PcbDebugObject } from "circuit-json"
 import type { INode as SvgObject } from "svgson"
-import { applyToPoint, type Matrix } from "transformation-matrix"
+import { type Matrix, applyToPoint } from "transformation-matrix"
 
 const DEBUG_COLOR = "#ff4d4d"
 
@@ -10,6 +10,31 @@ export interface PcbDebugObjectStyle {
   dashLength: number
   labelGap: number
   pointRadius: number
+}
+
+type DebugLabelAnchor = "start" | "middle" | "end"
+type RectLabelSide = "top" | "right" | "bottom" | "left"
+
+export interface PcbDebugObjectLabelLayout {
+  x: number
+  y: number
+  fontSize: number
+  anchor: DebugLabelAnchor
+  side?: RectLabelSide
+}
+
+interface Bounds {
+  left: number
+  top: number
+  right: number
+  bottom: number
+}
+
+interface DebugLabel {
+  debugObject: PcbDebugObject
+  label: string
+  layout: PcbDebugObjectLabelLayout
+  rectBounds?: Bounds
 }
 
 const textNode = (value: string): SvgObject => ({
@@ -22,16 +47,10 @@ const textNode = (value: string): SvgObject => ({
 
 const createLabel = ({
   label,
-  x,
-  y,
-  style,
-  anchor = "start",
+  layout,
 }: {
   label?: string
-  x: number
-  y: number
-  style: PcbDebugObjectStyle
-  anchor?: "start" | "middle"
+  layout: PcbDebugObjectLabelLayout
 }): SvgObject[] =>
   label
     ? [
@@ -40,13 +59,13 @@ const createLabel = ({
           type: "element",
           value: "",
           attributes: {
-            x: x.toString(),
-            y: y.toString(),
+            x: layout.x.toString(),
+            y: layout.y.toString(),
             fill: DEBUG_COLOR,
             "font-family": "monospace",
-            "font-size": style.fontSize.toString(),
+            "font-size": layout.fontSize.toString(),
             "font-weight": "600",
-            "text-anchor": anchor,
+            "text-anchor": layout.anchor,
           },
           children: [textNode(label)],
         },
@@ -62,16 +81,251 @@ const getCommonAttributes = (
   "data-debug-shape": debugObject.shape,
 })
 
-export function createSvgObjectsFromPcbDebugObject({
+const getRectBounds = (
+  debugObject: Extract<PcbDebugObject, { shape: "rect" }>,
+  transform: Matrix,
+): Bounds => {
+  const firstCorner = applyToPoint(transform, [
+    debugObject.center.x - debugObject.size.width / 2,
+    debugObject.center.y - debugObject.size.height / 2,
+  ])
+  const secondCorner = applyToPoint(transform, [
+    debugObject.center.x + debugObject.size.width / 2,
+    debugObject.center.y + debugObject.size.height / 2,
+  ])
+
+  return {
+    left: Math.min(firstCorner[0], secondCorner[0]),
+    top: Math.min(firstCorner[1], secondCorner[1]),
+    right: Math.max(firstCorner[0], secondCorner[0]),
+    bottom: Math.max(firstCorner[1], secondCorner[1]),
+  }
+}
+
+const createRectLabelLayout = ({
+  bounds,
+  side,
+  fontSize,
+  labelGap,
+}: {
+  bounds: Bounds
+  side: RectLabelSide
+  fontSize: number
+  labelGap: number
+}): PcbDebugObjectLabelLayout => {
+  switch (side) {
+    case "right":
+      return {
+        x: bounds.right + labelGap,
+        y: bounds.top + fontSize,
+        fontSize,
+        anchor: "start",
+        side,
+      }
+    case "bottom":
+      return {
+        x: bounds.left,
+        y: bounds.bottom + labelGap + fontSize,
+        fontSize,
+        anchor: "start",
+        side,
+      }
+    case "left":
+      return {
+        x: bounds.left - labelGap,
+        y: bounds.top + fontSize,
+        fontSize,
+        anchor: "end",
+        side,
+      }
+    default:
+      return {
+        x: bounds.left,
+        y: bounds.top - labelGap,
+        fontSize,
+        anchor: "start",
+        side: "top",
+      }
+  }
+}
+
+const getDefaultLabel = ({
   debugObject,
   transform,
   style,
-  labelStackIndex = 0,
 }: {
   debugObject: PcbDebugObject
   transform: Matrix
   style: PcbDebugObjectStyle
-  labelStackIndex?: number
+}): DebugLabel | null => {
+  if (!debugObject.label) return null
+
+  if (debugObject.shape === "rect") {
+    const rectBounds = getRectBounds(debugObject, transform)
+    return {
+      debugObject,
+      label: debugObject.label,
+      rectBounds,
+      layout: createRectLabelLayout({
+        bounds: rectBounds,
+        side: "top",
+        fontSize: style.fontSize,
+        labelGap: style.labelGap,
+      }),
+    }
+  }
+
+  if (debugObject.shape === "line") {
+    const [startX, startY] = applyToPoint(transform, [
+      debugObject.start.x,
+      debugObject.start.y,
+    ])
+    const [endX, endY] = applyToPoint(transform, [
+      debugObject.end.x,
+      debugObject.end.y,
+    ])
+
+    return {
+      debugObject,
+      label: debugObject.label,
+      layout: {
+        x: (startX + endX) / 2,
+        y: (startY + endY) / 2 - style.labelGap,
+        fontSize: style.fontSize,
+        anchor: "middle",
+      },
+    }
+  }
+
+  const [centerX, centerY] = applyToPoint(transform, [
+    debugObject.center.x,
+    debugObject.center.y,
+  ])
+  return {
+    debugObject,
+    label: debugObject.label,
+    layout: {
+      x: centerX + style.pointRadius + style.labelGap,
+      y: centerY - style.pointRadius,
+      fontSize: style.fontSize,
+      anchor: "start",
+    },
+  }
+}
+
+const getLabelBounds = ({ label, layout }: DebugLabel): Bounds => {
+  const width = Array.from(label).length * layout.fontSize * 0.6
+  let left = layout.x
+
+  if (layout.anchor === "middle") left -= width / 2
+  if (layout.anchor === "end") left -= width
+
+  return {
+    left,
+    right: left + width,
+    top: layout.y - layout.fontSize,
+    bottom: layout.y,
+  }
+}
+
+const boundsOverlap = (a: Bounds, b: Bounds): boolean =>
+  a.left < b.right && a.right > b.left && a.top < b.bottom && a.bottom > b.top
+
+const labelsOverlap = (a: DebugLabel, b: DebugLabel): boolean =>
+  boundsOverlap(getLabelBounds(a), getLabelBounds(b))
+
+/**
+ * Layout all PCB debug labels together so collisions can be resolved before the
+ * individual SVG groups are created.
+ */
+export function getPcbDebugObjectLabelLayouts({
+  debugObjects,
+  transform,
+  style,
+}: {
+  debugObjects: PcbDebugObject[]
+  transform: Matrix
+  style: PcbDebugObjectStyle
+}): Map<string, PcbDebugObjectLabelLayout> {
+  const labels = debugObjects
+    .map((debugObject) => getDefaultLabel({ debugObject, transform, style }))
+    .filter((label): label is DebugLabel => label !== null)
+  const labelsToShrink = new Set<number>()
+
+  for (let i = 0; i < labels.length; i++) {
+    for (let j = i + 1; j < labels.length; j++) {
+      if (labelsOverlap(labels[i]!, labels[j]!)) {
+        labelsToShrink.add(i)
+        labelsToShrink.add(j)
+      }
+    }
+  }
+
+  for (const index of labelsToShrink) {
+    const label = labels[index]!
+    label.layout = {
+      ...label.layout,
+      fontSize: label.layout.fontSize * 0.5,
+    }
+  }
+
+  // Preserve earlier labels where possible and move later colliding rectangle
+  // labels to the first completely free outside edge.
+  const sideOrder: RectLabelSide[] = ["top", "right", "bottom", "left"]
+  for (let i = labels.length - 1; i >= 0; i--) {
+    const label = labels[i]!
+    if (!label.rectBounds) continue
+
+    const overlapsAnotherLabel = labels.some(
+      (other, otherIndex) => otherIndex !== i && labelsOverlap(label, other),
+    )
+    if (!overlapsAnotherLabel) continue
+
+    const currentSide = label.layout.side ?? "top"
+    const currentSideIndex = sideOrder.indexOf(currentSide)
+    const alternativeSides = [
+      ...sideOrder.slice(currentSideIndex + 1),
+      ...sideOrder.slice(0, currentSideIndex),
+    ]
+
+    for (const side of alternativeSides) {
+      const candidateLayout = createRectLabelLayout({
+        bounds: label.rectBounds,
+        side,
+        fontSize: label.layout.fontSize,
+        labelGap: style.labelGap,
+      })
+      const candidate = { ...label, layout: candidateLayout }
+      const candidateOverlaps = labels.some(
+        (other, otherIndex) =>
+          otherIndex !== i && labelsOverlap(candidate, other),
+      )
+
+      if (!candidateOverlaps) {
+        label.layout = candidateLayout
+        break
+      }
+    }
+  }
+
+  return new Map(
+    labels.map(({ debugObject, layout }) => [
+      debugObject.pcb_debug_object_id,
+      layout,
+    ]),
+  )
+}
+
+export function createSvgObjectsFromPcbDebugObject({
+  debugObject,
+  transform,
+  style,
+  labelLayout,
+}: {
+  debugObject: PcbDebugObject
+  transform: Matrix
+  style: PcbDebugObjectStyle
+  labelLayout?: PcbDebugObjectLabelLayout
 }): SvgObject[] {
   const commonAttributes = getCommonAttributes(debugObject)
   const strokeAttributes = {
@@ -82,18 +336,17 @@ export function createSvgObjectsFromPcbDebugObject({
   }
 
   if (debugObject.shape === "rect") {
-    const firstCorner = applyToPoint(transform, [
-      debugObject.center.x - debugObject.size.width / 2,
-      debugObject.center.y - debugObject.size.height / 2,
-    ])
-    const secondCorner = applyToPoint(transform, [
-      debugObject.center.x + debugObject.size.width / 2,
-      debugObject.center.y + debugObject.size.height / 2,
-    ])
-    const left = Math.min(firstCorner[0], secondCorner[0])
-    const top = Math.min(firstCorner[1], secondCorner[1])
-    const width = Math.abs(secondCorner[0] - firstCorner[0])
-    const height = Math.abs(secondCorner[1] - firstCorner[1])
+    const bounds = getRectBounds(debugObject, transform)
+    const width = bounds.right - bounds.left
+    const height = bounds.bottom - bounds.top
+    const layout =
+      labelLayout ??
+      createRectLabelLayout({
+        bounds,
+        side: "top",
+        fontSize: style.fontSize,
+        labelGap: style.labelGap,
+      })
 
     return [
       {
@@ -107,8 +360,8 @@ export function createSvgObjectsFromPcbDebugObject({
             type: "element",
             value: "",
             attributes: {
-              x: left.toString(),
-              y: top.toString(),
+              x: bounds.left.toString(),
+              y: bounds.top.toString(),
               width: width.toString(),
               height: height.toString(),
               ...strokeAttributes,
@@ -117,12 +370,7 @@ export function createSvgObjectsFromPcbDebugObject({
           },
           ...createLabel({
             label: debugObject.label,
-            x: left,
-            y:
-              top -
-              style.labelGap -
-              labelStackIndex * (style.fontSize + style.labelGap),
-            style,
+            layout,
           }),
         ],
       },
@@ -138,6 +386,12 @@ export function createSvgObjectsFromPcbDebugObject({
       debugObject.end.x,
       debugObject.end.y,
     ])
+    const layout = labelLayout ?? {
+      x: (startX + endX) / 2,
+      y: (startY + endY) / 2 - style.labelGap,
+      fontSize: style.fontSize,
+      anchor: "middle" as const,
+    }
 
     return [
       {
@@ -161,10 +415,7 @@ export function createSvgObjectsFromPcbDebugObject({
           },
           ...createLabel({
             label: debugObject.label,
-            x: (startX + endX) / 2,
-            y: (startY + endY) / 2 - style.labelGap,
-            style,
-            anchor: "middle",
+            layout,
           }),
         ],
       },
@@ -175,6 +426,12 @@ export function createSvgObjectsFromPcbDebugObject({
     debugObject.center.x,
     debugObject.center.y,
   ])
+  const layout = labelLayout ?? {
+    x: centerX + style.pointRadius + style.labelGap,
+    y: centerY - style.pointRadius,
+    fontSize: style.fontSize,
+    anchor: "start" as const,
+  }
 
   return [
     {
@@ -197,9 +454,7 @@ export function createSvgObjectsFromPcbDebugObject({
         },
         ...createLabel({
           label: debugObject.label,
-          x: centerX + style.pointRadius + style.labelGap,
-          y: centerY - style.pointRadius,
-          style,
+          layout,
         }),
       ],
     },

--- a/tests/pcb/pcb-debug-object.test.ts
+++ b/tests/pcb/pcb-debug-object.test.ts
@@ -1,6 +1,8 @@
 import { expect, test } from "bun:test"
-import type { AnyCircuitElement } from "circuit-json"
+import type { AnyCircuitElement, PcbDebugObject } from "circuit-json"
 import { convertCircuitJsonToPcbSvg } from "lib"
+import { getPcbDebugObjectLabelLayouts } from "lib/pcb/svg-object-fns/create-svg-objects-from-pcb-debug-object"
+import { identity } from "transformation-matrix"
 
 const circuitJson: AnyCircuitElement[] = [
   {
@@ -68,4 +70,67 @@ test("debug styles scale with the output viewport", () => {
   expect(smallSvg).toContain('stroke-width="1"')
   expect(largeSvg).toContain('font-size="18"')
   expect(largeSvg).toContain('stroke-width="1.8"')
+})
+
+const collisionTestStyle = {
+  fontSize: 20,
+  strokeWidth: 1,
+  dashLength: 4,
+  labelGap: 5,
+  pointRadius: 3,
+}
+
+const createDebugRect = ({
+  id,
+  x,
+  label,
+}: {
+  id: string
+  x: number
+  label: string
+}): PcbDebugObject => ({
+  type: "pcb_debug_object",
+  pcb_debug_object_id: id,
+  shape: "rect",
+  center: { x, y: 5 },
+  size: { width: 10, height: 10 },
+  label,
+})
+
+test("overlapping debug labels shrink before changing rectangle sides", () => {
+  const layouts = getPcbDebugObjectLabelLayouts({
+    debugObjects: [
+      createDebugRect({ id: "a", x: 5, label: "AAAAA" }),
+      createDebugRect({ id: "b", x: 45, label: "BBBBB" }),
+    ],
+    transform: identity(),
+    style: collisionTestStyle,
+  })
+
+  expect(layouts.get("a")).toMatchObject({ fontSize: 10, side: "top" })
+  expect(layouts.get("b")).toMatchObject({ fontSize: 10, side: "top" })
+})
+
+test("rectangle debug labels move outside another side when shrinking is insufficient", () => {
+  const layouts = getPcbDebugObjectLabelLayouts({
+    debugObjects: [
+      createDebugRect({ id: "a", x: 5, label: "AAAAA" }),
+      createDebugRect({ id: "b", x: 5, label: "BBBBB" }),
+    ],
+    transform: identity(),
+    style: collisionTestStyle,
+  })
+
+  expect(layouts.get("a")).toMatchObject({
+    x: 0,
+    y: -5,
+    fontSize: 10,
+    side: "top",
+  })
+  expect(layouts.get("b")).toMatchObject({
+    x: 15,
+    y: 10,
+    fontSize: 10,
+    side: "right",
+  })
 })


### PR DESCRIPTION
## Summary

- detect collisions between PCB debug-object labels before rendering
- shrink both colliding labels by 50% and retain their positions when that resolves the overlap
- move unresolved rectangle-label collisions to an available outside edge without placing text inside the rectangle
- add focused coverage for shrink-only and shrink-then-move behavior

## Validation

- `bun test` — 347 passed, 1 todo
- `npm run build`
- `bunx tsc --noEmit`
