### PR TITLE
feat: render schematic text overline ranges

### DIFF
--- a/lib/sch/svg-object-fns/create-svg-objects-for-sch-text.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-for-sch-text.ts
@@ -2,14 +2,24 @@ import type { SchematicText } from "circuit-json"
 import type { SvgObject } from "lib/svg-object"
 import type { ColorMap } from "lib/utils/colors"
 import { getSchScreenFontSize } from "lib/utils/get-sch-font-size"
-import { applyToPoint, type Matrix } from "transformation-matrix"
+import { type Matrix, applyToPoint } from "transformation-matrix"
+
+type TextDecorationRange = {
+  start: number
+  end: number
+  decoration: "overline" | "underline" | "line-through"
+}
+
+type SchematicTextWithDecorations = SchematicText & {
+  text_decoration_ranges?: TextDecorationRange[]
+}
 
 export const createSvgSchText = ({
   elm,
   transform,
   colorMap,
 }: {
-  elm: SchematicText
+  elm: SchematicTextWithDecorations
   transform: Matrix
   colorMap: ColorMap
 }): SvgObject => {
@@ -80,8 +90,13 @@ export const createSvgSchText = ({
 
   const lines = elm.text.split("\n")
 
-  const children: SvgObject[] =
-    lines.length === 1
+  const children: SvgObject[] = elm.text_decoration_ranges?.length
+    ? createDecoratedTextChildren(
+        elm.text,
+        elm.text_decoration_ranges,
+        elm.schematic_text_id,
+      )
+    : lines.length === 1
       ? [
           {
             type: "text",
@@ -127,4 +142,44 @@ export const createSvgSchText = ({
     },
     children,
   }
+}
+
+const createDecoratedTextChildren = (
+  text: string,
+  ranges: TextDecorationRange[],
+  schematicTextId: string,
+): SvgObject[] => {
+  const characters = Array.from(text)
+  const boundaries = new Set([0, characters.length])
+  for (const range of ranges) {
+    boundaries.add(range.start)
+    boundaries.add(range.end)
+  }
+  const sortedBoundaries = [...boundaries].sort((a, b) => a - b)
+
+  return sortedBoundaries.slice(0, -1).map((start, index) => {
+    const end = sortedBoundaries[index + 1]
+    const decorations = ranges
+      .filter((range) => range.start <= start && range.end >= end)
+      .map((range) => range.decoration)
+
+    return {
+      type: "element",
+      name: "tspan",
+      value: "",
+      attributes:
+        decorations.length > 0
+          ? { style: `text-decoration: ${decorations.join(" ")};` }
+          : {},
+      children: [
+        {
+          type: "text",
+          value: characters.slice(start, end).join(""),
+          name: index === 0 ? schematicTextId : "",
+          attributes: {},
+          children: [],
+        },
+      ],
+    }
+  })
 }

--- a/lib/sch/svg-object-fns/create-svg-objects-for-sch-text.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-for-sch-text.ts
@@ -4,14 +4,13 @@ import type { ColorMap } from "lib/utils/colors"
 import { getSchScreenFontSize } from "lib/utils/get-sch-font-size"
 import { type Matrix, applyToPoint } from "transformation-matrix"
 
-type TextDecorationRange = {
-  start: number
-  end: number
-  decoration: "overline" | "underline" | "line-through"
+type OverlineRange = {
+  start_index: number
+  end_index: number
 }
 
-type SchematicTextWithDecorations = SchematicText & {
-  text_decoration_ranges?: TextDecorationRange[]
+type SchematicTextWithOverlines = SchematicText & {
+  overline_ranges?: OverlineRange[]
 }
 
 export const createSvgSchText = ({
@@ -19,7 +18,7 @@ export const createSvgSchText = ({
   transform,
   colorMap,
 }: {
-  elm: SchematicTextWithDecorations
+  elm: SchematicTextWithOverlines
   transform: Matrix
   colorMap: ColorMap
 }): SvgObject => {
@@ -90,10 +89,10 @@ export const createSvgSchText = ({
 
   const lines = elm.text.split("\n")
 
-  const children: SvgObject[] = elm.text_decoration_ranges?.length
-    ? createDecoratedTextChildren(
+  const children: SvgObject[] = elm.overline_ranges?.length
+    ? createTextChildrenWithOverlines(
         elm.text,
-        elm.text_decoration_ranges,
+        elm.overline_ranges,
         elm.schematic_text_id,
       )
     : lines.length === 1
@@ -144,33 +143,30 @@ export const createSvgSchText = ({
   }
 }
 
-const createDecoratedTextChildren = (
+const createTextChildrenWithOverlines = (
   text: string,
-  ranges: TextDecorationRange[],
+  ranges: OverlineRange[],
   schematicTextId: string,
 ): SvgObject[] => {
   const characters = Array.from(text)
   const boundaries = new Set([0, characters.length])
   for (const range of ranges) {
-    boundaries.add(range.start)
-    boundaries.add(range.end)
+    boundaries.add(range.start_index)
+    boundaries.add(range.end_index)
   }
   const sortedBoundaries = [...boundaries].sort((a, b) => a - b)
 
   return sortedBoundaries.slice(0, -1).map((start, index) => {
     const end = sortedBoundaries[index + 1]
-    const decorations = ranges
-      .filter((range) => range.start <= start && range.end >= end)
-      .map((range) => range.decoration)
+    const hasOverline = ranges.some(
+      (range) => range.start_index <= start && range.end_index >= end,
+    )
 
     return {
       type: "element",
       name: "tspan",
       value: "",
-      attributes:
-        decorations.length > 0
-          ? { style: `text-decoration: ${decorations.join(" ")};` }
-          : {},
+      attributes: hasOverline ? { style: "text-decoration: overline;" } : {},
       children: [
         {
           type: "text",

--- a/tests/sch/schematic-text-decoration-ranges.test.ts
+++ b/tests/sch/schematic-text-decoration-ranges.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "bun:test"
+import type { SchematicText } from "circuit-json"
+import { convertCircuitJsonToSchematicSvg } from "lib/index"
+
+test("renders text decoration ranges as styled tspans", () => {
+  const text = {
+    type: "schematic_text",
+    schematic_text_id: "decorated_text",
+    text: "RESET/GPIO",
+    text_decoration_ranges: [{ start: 0, end: 5, decoration: "overline" }],
+    font_size: 0.18,
+    position: { x: 0, y: 0 },
+    rotation: 0,
+    anchor: "center",
+    color: "#000000",
+  } satisfies SchematicText & {
+    text_decoration_ranges: Array<{
+      start: number
+      end: number
+      decoration: "overline"
+    }>
+  }
+
+  const svg = convertCircuitJsonToSchematicSvg([text])
+
+  expect(svg).toContain('style="text-decoration: overline;"')
+  expect(svg).toContain(">RESET</tspan>")
+  expect(svg).toContain(">/GPIO</tspan>")
+})

--- a/tests/sch/schematic-text-overline-ranges.test.ts
+++ b/tests/sch/schematic-text-overline-ranges.test.ts
@@ -2,22 +2,21 @@ import { expect, test } from "bun:test"
 import type { SchematicText } from "circuit-json"
 import { convertCircuitJsonToSchematicSvg } from "lib/index"
 
-test("renders text decoration ranges as styled tspans", () => {
+test("renders overline ranges as styled tspans", () => {
   const text = {
     type: "schematic_text",
     schematic_text_id: "decorated_text",
     text: "RESET/GPIO",
-    text_decoration_ranges: [{ start: 0, end: 5, decoration: "overline" }],
+    overline_ranges: [{ start_index: 0, end_index: 5 }],
     font_size: 0.18,
     position: { x: 0, y: 0 },
     rotation: 0,
     anchor: "center",
     color: "#000000",
   } satisfies SchematicText & {
-    text_decoration_ranges: Array<{
-      start: number
-      end: number
-      decoration: "overline"
+    overline_ranges: Array<{
+      start_index: number
+      end_index: number
     }>
   }
 


### PR DESCRIPTION
Renders `schematic_text.overline_ranges` as native SVG `<tspan>` elements using `text-decoration: overline`. The explicit `start_index` and `end_index` values split only the marked Unicode character span, so SVG and font metrics produce one continuous overline without hard-coded widths, baseline offsets, extra line geometry, or box-drawing glyphs. Depends on tscircuit/circuit-json#747.

Motive: Render partial active-low names accurately while keeping layout decisions inside the text renderer.