### PR TITLE
fix: guard non-finite silkscreen sizes and keepout radii

### DIFF
--- a/lib/pcb/get-pcb-bounds-from-circuit-json.ts
+++ b/lib/pcb/get-pcb-bounds-from-circuit-json.ts
@@ -387,7 +387,7 @@ export function getComprehensivePcbBounds(
           typeof keepout.radius === "number"
             ? keepout.radius
             : (distance.parse(keepout.radius) ?? 0)
-        if (radius > 0) {
+        if (Number.isFinite(radius) && radius > 0) {
           updateBounds({
             center: keepout.center,
             width: radius * 2,

--- a/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-keepout.ts
+++ b/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-keepout.ts
@@ -186,7 +186,10 @@ export function createSvgObjectsFromPcbKeepout(
         circleKeepout.center.x,
         circleKeepout.center.y,
       ])
-      const scaledRadius = circleKeepout.radius * Math.abs(transform.a)
+      const radius = Number.isFinite(circleKeepout.radius)
+        ? circleKeepout.radius
+        : 0
+      const scaledRadius = radius * Math.abs(transform.a)
 
       const backgroundAttributes = {
         ...createKeepoutBaseAttributes(

--- a/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-silkscreen-text.ts
+++ b/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-silkscreen-text.ts
@@ -51,7 +51,7 @@ export function createSvgObjectsFromPcbSilkscreenText(
   const {
     anchor_position,
     text,
-    font_size = 1,
+    font_size: rawFontSize = 1,
     layer = "top",
     ccw_rotation = 0,
     anchor_alignment = "center",
@@ -59,6 +59,8 @@ export function createSvgObjectsFromPcbSilkscreenText(
     knockout_padding,
     is_mirrored = false,
   } = pcbSilkscreenText
+
+  const font_size = Number.isFinite(rawFontSize) ? rawFontSize : 1
 
   if (layerFilter && layer !== layerFilter) return []
 

--- a/tests/pcb/pcb-non-finite-text-and-keepout.test.ts
+++ b/tests/pcb/pcb-non-finite-text-and-keepout.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToPcbSvg } from "lib"
+
+const board: AnyCircuitElement = {
+  type: "pcb_board",
+  pcb_board_id: "board_0",
+  center: { x: 0, y: 0 },
+  width: 20,
+  height: 20,
+  material: "fr4",
+  num_layers: 2,
+  thickness: 1.6,
+}
+
+test("non-finite silkscreen sizes use the default for normal and knockout text", () => {
+  const render = (font_size: number, is_knockout: boolean) =>
+    convertCircuitJsonToPcbSvg([
+      board,
+      {
+        type: "pcb_silkscreen_text",
+        pcb_silkscreen_text_id: "text_0",
+        pcb_component_id: "component_0",
+        anchor_position: { x: 1, y: 2 },
+        anchor_alignment: "top_left",
+        layer: "top",
+        font: "tscircuit2024",
+        text: "Default\nsize",
+        font_size,
+        is_knockout,
+      },
+    ]).replace(/silkscreen-knockout-mask-text_0-\d+/g, "knockout-mask")
+
+  for (const knockout of [false, true]) {
+    const expected = render(1, knockout)
+    expect(expected).not.toMatch(/NaN|Infinity/)
+    for (const invalid of [NaN, Infinity, -Infinity]) {
+      expect(render(invalid, knockout)).toBe(expected)
+    }
+    expect(render(2, knockout)).not.toBe(expected)
+  }
+})
+
+test("non-finite keepout radii render like zero without corrupting board bounds", () => {
+  const render = (radius: number) =>
+    convertCircuitJsonToPcbSvg([
+      board,
+      {
+        type: "pcb_keepout",
+        pcb_keepout_id: "keepout_0",
+        shape: "circle",
+        center: { x: 1, y: 2 },
+        radius,
+        layers: ["top", "bottom"],
+      },
+    ])
+
+  const expected = render(0)
+  expect(expected).not.toMatch(/NaN|Infinity/)
+  for (const invalid of [NaN, Infinity, -Infinity]) {
+    expect(render(invalid)).toBe(expected)
+  }
+  expect(render(3)).not.toBe(expected)
+})

--- a/tests/pcb/pcb-non-finite-text-and-keepout1.test.ts
+++ b/tests/pcb/pcb-non-finite-text-and-keepout1.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToPcbSvg } from "lib"
+
+const board: AnyCircuitElement = {
+  type: "pcb_board",
+  pcb_board_id: "board_0",
+  center: { x: 0, y: 0 },
+  width: 20,
+  height: 20,
+  material: "fr4",
+  num_layers: 2,
+  thickness: 1.6,
+}
+
+test("non-finite silkscreen sizes use the default for normal and knockout text", () => {
+  const render = (font_size: number, is_knockout: boolean) =>
+    convertCircuitJsonToPcbSvg([
+      board,
+      {
+        type: "pcb_silkscreen_text",
+        pcb_silkscreen_text_id: "text_0",
+        pcb_component_id: "component_0",
+        anchor_position: { x: 1, y: 2 },
+        anchor_alignment: "top_left",
+        layer: "top",
+        font: "tscircuit2024",
+        text: "Default\nsize",
+        font_size,
+        is_knockout,
+      },
+    ]).replace(/silkscreen-knockout-mask-text_0-\d+/g, "knockout-mask")
+
+  for (const knockout of [false, true]) {
+    const expected = render(1, knockout)
+    expect(expected).not.toMatch(/NaN|Infinity/)
+    for (const invalid of [NaN, Infinity, -Infinity]) {
+      expect(render(invalid, knockout)).toBe(expected)
+    }
+    expect(render(2, knockout)).not.toBe(expected)
+  }
+})

--- a/tests/pcb/pcb-non-finite-text-and-keepout2.test.ts
+++ b/tests/pcb/pcb-non-finite-text-and-keepout2.test.ts
@@ -13,34 +13,6 @@ const board: AnyCircuitElement = {
   thickness: 1.6,
 }
 
-test("non-finite silkscreen sizes use the default for normal and knockout text", () => {
-  const render = (font_size: number, is_knockout: boolean) =>
-    convertCircuitJsonToPcbSvg([
-      board,
-      {
-        type: "pcb_silkscreen_text",
-        pcb_silkscreen_text_id: "text_0",
-        pcb_component_id: "component_0",
-        anchor_position: { x: 1, y: 2 },
-        anchor_alignment: "top_left",
-        layer: "top",
-        font: "tscircuit2024",
-        text: "Default\nsize",
-        font_size,
-        is_knockout,
-      },
-    ]).replace(/silkscreen-knockout-mask-text_0-\d+/g, "knockout-mask")
-
-  for (const knockout of [false, true]) {
-    const expected = render(1, knockout)
-    expect(expected).not.toMatch(/NaN|Infinity/)
-    for (const invalid of [NaN, Infinity, -Infinity]) {
-      expect(render(invalid, knockout)).toBe(expected)
-    }
-    expect(render(2, knockout)).not.toBe(expected)
-  }
-})
-
 test("non-finite keepout radii render like zero without corrupting board bounds", () => {
   const render = (radius: number) =>
     convertCircuitJsonToPcbSvg([


### PR DESCRIPTION
Non-finite silkscreen font sizes and circular keepout radii currently reach SVG attributes as `NaN` or `Infinity`. Use the existing font-size default of 1 for non-finite text sizes and a zero radius for non-finite circular keepouts. Ignore non-finite keepout radii in board bounds as well, so an infinite radius cannot corrupt the viewport.

The font-size fallback applies before both normal and knockout text geometry. Finite values retain their existing behavior.

Fixes #636. Credit to the original report and earlier unmerged PRs #637 and #671. This regression coverage exercises current main, including knockout text and bounds.

Validation:
- Both new regression tests failed before the fix and pass afterward. They compare complete rendered SVG output with the documented fallback values for NaN and positive/negative infinity.
- Nine targeted tests passed (24 assertions), including existing keepout, text, multiline-text, and knockout visual snapshots.
- `bunx tsc --noEmit` passed.
- Biome formatting passed for the four changed files.

Patch-level rendering fix; no dependencies or public types changed.
