### PR TITLE
fix(sch): keep non-finite schematic component sizes out of the SVG (#638)

### DIFF
--- a/lib/sch/get-finite-schematic-component-size.ts
+++ b/lib/sch/get-finite-schematic-component-size.ts
@@ -1,0 +1,10 @@
+import type { SchematicComponent } from "circuit-json"
+
+export function getFiniteSchematicComponentSize(
+  size: SchematicComponent["size"],
+): SchematicComponent["size"] {
+  return {
+    width: Number.isFinite(size.width) ? size.width : 0,
+    height: Number.isFinite(size.height) ? size.height : 0,
+  }
+}

--- a/lib/sch/get-schematic-bounds-from-circuit-json.ts
+++ b/lib/sch/get-schematic-bounds-from-circuit-json.ts
@@ -17,6 +17,7 @@ import { estimateTextWidth } from "./estimate-text-width"
 import { getSchematicSymbolTextBounds } from "./get-schematic-symbol-text-bounds"
 import { getTableDimensions } from "./get-table-dimensions"
 import { getSchematicSheetLayout } from "./schematic-sheet-utils"
+import { getFiniteSchematicComponentSize } from "./get-finite-schematic-component-size"
 
 interface Bounds {
   minX: number
@@ -45,7 +46,7 @@ export function getSchematicBoundsFromCircuitJson(
         0,
       )
     } else if (item.type === "schematic_component") {
-      updateBounds(item.center, item.size, 0)
+      updateBounds(item.center, getFiniteSchematicComponentSize(item.size), 0)
     } else if (item.type === "schematic_port") {
       updateBounds(item.center, { width: portSize, height: portSize }, 0)
     } else if (item.type === "schematic_debug_object") {

--- a/lib/sch/svg-object-fns/create-svg-objects-from-sch-component-with-box.ts
+++ b/lib/sch/svg-object-fns/create-svg-objects-from-sch-component-with-box.ts
@@ -15,6 +15,7 @@ import { createSvgObjectsFromSchPortOnBox } from "./create-svg-objects-from-sch-
 import { getSchStrokeSize } from "lib/utils/get-sch-stroke-size"
 import { getSchScreenFontSize } from "lib/utils/get-sch-font-size"
 import { createSvgSchText } from "./create-svg-objects-for-sch-text"
+import { getFiniteSchematicComponentSize } from "../get-finite-schematic-component-size"
 
 export const createSvgObjectsFromSchematicComponentWithBox = ({
   component: schComponent,
@@ -28,14 +29,15 @@ export const createSvgObjectsFromSchematicComponentWithBox = ({
   colorMap: ColorMap
 }): SvgObject[] => {
   const svgObjects: SvgObject[] = []
+  const size = getFiniteSchematicComponentSize(schComponent.size)
 
   const componentScreenTopLeft = applyToPoint(transform, {
-    x: schComponent.center.x - schComponent.size.width / 2,
-    y: schComponent.center.y + schComponent.size.height / 2,
+    x: schComponent.center.x - size.width / 2,
+    y: schComponent.center.y + size.height / 2,
   })
   const componentScreenBottomRight = applyToPoint(transform, {
-    x: schComponent.center.x + schComponent.size.width / 2,
-    y: schComponent.center.y - schComponent.size.height / 2,
+    x: schComponent.center.x + size.width / 2,
+    y: schComponent.center.y - size.height / 2,
   })
   const componentScreenWidth =
     componentScreenBottomRight.x - componentScreenTopLeft.x

--- a/tests/sch/non-finite-component-size.test.ts
+++ b/tests/sch/non-finite-component-size.test.ts
@@ -1,0 +1,78 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement, SchematicComponent } from "circuit-json"
+import { convertCircuitJsonToSchematicSvg } from "lib"
+import { getSchematicBoundsFromCircuitJson } from "lib/sch/get-schematic-bounds-from-circuit-json"
+
+function getComponent(size: SchematicComponent["size"]): SchematicComponent {
+  return {
+    type: "schematic_component",
+    schematic_component_id: "sch_u1",
+    source_component_id: "source_u1",
+    center: { x: 20, y: 10 },
+    size,
+    is_box_with_pins: true,
+  }
+}
+
+for (const dimension of ["width", "height"] as const) {
+  for (const invalidSize of [Number.NaN, Infinity, -Infinity]) {
+    test(`${dimension}=${invalidSize} preserves finite SVG geometry and viewport bounds`, () => {
+      const size = { width: 4, height: 2, [dimension]: invalidSize }
+      const component = getComponent(size)
+      const circuitJson: AnyCircuitElement[] = [
+        {
+          type: "source_component",
+          source_component_id: "source_u1",
+          name: "U1",
+          ftype: "simple_chip",
+        },
+        component,
+        {
+          type: "source_port",
+          source_port_id: "source_pin1",
+          source_component_id: "source_u1",
+          name: "EN",
+        },
+        {
+          type: "schematic_port",
+          schematic_port_id: "sch_pin1",
+          source_port_id: "source_pin1",
+          schematic_component_id: "sch_u1",
+          center: { x: 17.6, y: 10 },
+          side_of_component: "left",
+          pin_number: 1,
+          display_pin_label: "EN",
+        },
+        {
+          ...getComponent({ width: 2, height: 2 }),
+          schematic_component_id: "sch_u2",
+          center: { x: -10, y: -5 },
+        },
+      ]
+
+      const bounds = getSchematicBoundsFromCircuitJson(circuitJson, 0)
+      expect(bounds.minX).toBe(-11)
+      expect(bounds.minY).toBe(-6)
+      expect(bounds.maxX).toBe(dimension === "width" ? 20 : 22)
+      expect(bounds.maxY).toBe(dimension === "height" ? 10.1 : 11)
+
+      const svg = convertCircuitJsonToSchematicSvg(circuitJson)
+      expect(svg).not.toMatch(/NaN|Infinity/)
+      expect(svg).toContain("sch-component-body")
+      expect(svg).toContain("sch-component-overlay")
+      expect(svg).toContain("sch-pin-number")
+      expect(svg).toContain("EN")
+      expect(component.size).toBe(size)
+      expect(Object.is(component.size[dimension], invalidSize)).toBe(true)
+    })
+  }
+}
+
+test("finite component sizes retain their exact bounds", () => {
+  expect(
+    getSchematicBoundsFromCircuitJson(
+      [getComponent({ width: 4.125, height: 2.25 })],
+      0,
+    ),
+  ).toEqual({ minX: 17.9375, maxX: 22.0625, minY: 8.875, maxY: 11.125 })
+})


### PR DESCRIPTION
Fixes #638

## Problem

A `schematic_component` whose `size.width` or `size.height` is non-finite (`NaN`/`Infinity`, e.g. from an unparseable `schWidth="abc"`) propagates through every derived screen coordinate. The output carries `NaN` in `x`, `y`, `width`, `height`, `transform`, `x1/y1/x2/y2` and `cx/cy` — none of which is a valid SVG length — so renderers discard the body rect, the pin lines and the labels, and the component simply disappears.

There is a second effect the issue does not mention: `getSchematicBoundsFromCircuitJson` feeds the same size into `updateBounds`, so one bad component turns the whole-sheet `minX/maxX/minY/maxY` into `NaN`. The viewBox is then invalid and **every other component on the sheet** stops rendering too.

## Fix

Treat a non-finite dimension as `0` at the two places the size is consumed, through a small shared helper `getFiniteSchematicComponentSize`:

- `lib/sch/svg-object-fns/create-svg-objects-from-sch-component-with-box.ts` — the box geometry
- `lib/sch/get-schematic-bounds-from-circuit-json.ts` — the sheet bounds

Finite sizes take exactly the same path as before, and the helper returns a new object, so the input circuit JSON is never mutated.

## Tests

`tests/sch/non-finite-component-size.test.ts` covers `NaN`, `Infinity` and `-Infinity` on both `width` and `height` (6 cases). Each asserts that:

- the SVG contains no `NaN`/`Infinity`
- the body, the overlay, the pin number and the pin label are still emitted
- the sheet bounds stay finite and a *second, valid* component on the same sheet keeps its exact bounds
- the input `size` object is untouched, with the original non-finite value still in place

A seventh test pins the exact bounds of a normal finite component, so the helper cannot silently change valid geometry.

All 7 fail on `main` (6 of them) and pass with this change; `tsc --noEmit` is clean and `biome format` has been applied.

Note on the wider suite: this checkout has ~76 pre-existing failures on unmodified `main`, all from PNG snapshot comparisons (local font rendering). I diffed the failure list before and after the patch — the schematic file closest to this change, `tests/features/show-errors-in-text-overlay.test.ts`, goes from 3 failures on `main` to 2 with the patch; no test regresses because of it.