### PR TITLE
fix: honor ccw_rotation when drawing and measuring hole_with_polygon_pad pads

### DIFF
--- a/lib/pcb/get-pcb-bounds-from-circuit-json.ts
+++ b/lib/pcb/get-pcb-bounds-from-circuit-json.ts
@@ -13,6 +13,7 @@ import {
   type PcbTraceRoutePoint,
 } from "./get-pcb-trace-segments"
 import { getTextCenterFromAnchorPosition } from "./get-text-center-from-anchor-position"
+import { rotatePointCcwDeg } from "lib/utils/rotate-point"
 
 export interface PcbBounds {
   minX: number
@@ -152,12 +153,17 @@ export function getComprehensivePcbBounds(
           ccwRotationDegrees: platedHole.rect_ccw_rotation,
         })
       } else if (platedHole.shape === "hole_with_polygon_pad") {
-        // pad_outline points are relative to the hole position
+        // pad_outline points are relative to the hole position in the pad's
+        // local frame; ccw_rotation rotates that frame about the hole center
+        const ccwRotation = platedHole.ccw_rotation ?? 0
         updateTraceBounds(
-          (platedHole.pad_outline ?? []).map((point) => ({
-            x: platedHole.x + point.x,
-            y: platedHole.y + point.y,
-          })),
+          (platedHole.pad_outline ?? []).map((point) => {
+            const rotated = rotatePointCcwDeg(point.x, point.y, ccwRotation)
+            return {
+              x: platedHole.x + rotated.x,
+              y: platedHole.y + rotated.y,
+            }
+          }),
         )
       }
     } else if (circuitJsonElm.type === "pcb_hole") {

--- a/lib/pcb/svg-object-fns/create-svg-object-from-pcb-pad-pin-number.ts
+++ b/lib/pcb/svg-object-fns/create-svg-object-from-pcb-pad-pin-number.ts
@@ -3,6 +3,7 @@ import type { SvgObject } from "lib/svg-object"
 import { applyToPoint } from "transformation-matrix"
 import type { PcbContext } from "../convert-circuit-json-to-pcb-svg"
 import { getPadPinNumber } from "./get-pad-data-attributes"
+import { rotatePointCcwDeg } from "lib/utils/rotate-point"
 
 type PcbPad = PcbSmtPad | PcbPlatedHole
 
@@ -138,14 +139,20 @@ function getPadTextGeometry(pad: PcbPad): PadTextGeometry | undefined {
   }
 
   if (pad.shape === "hole_with_polygon_pad") {
-    const polygonGeometry = getPolygonGeometry(pad.pad_outline)
+    // The outline is relative to the hole position in the pad's local frame;
+    // ccw_rotation rotates that frame about the hole center
+    const ccwRotation = pad.ccw_rotation ?? 0
+    const rotatedOutline = pad.pad_outline.map((point) =>
+      rotatePointCcwDeg(point.x, point.y, ccwRotation),
+    )
+    const polygonGeometry = getPolygonGeometry(rotatedOutline)
     if (!polygonGeometry) return undefined
 
     return {
       ...polygonGeometry,
       centerX: pad.x + polygonGeometry.centerX,
       centerY: pad.y + polygonGeometry.centerY,
-      ccwRotation: 0,
+      ccwRotation,
     }
   }
 

--- a/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-plated-hole.ts
+++ b/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-plated-hole.ts
@@ -8,6 +8,7 @@ import { applyToPoint } from "transformation-matrix"
 import type { SvgObject } from "lib/svg-object"
 import type { PcbContext } from "../convert-circuit-json-to-pcb-svg"
 import { getPadDataAttributes } from "./get-pad-data-attributes"
+import { rotatePointCcwDeg } from "lib/utils/rotate-point"
 
 type HoleWithRectPadOffsets = {
   hole_offset_x?: number
@@ -939,19 +940,30 @@ export function createSvgObjectsFromPcbPlatedHole(
     const padOutline = polygonHole.pad_outline || []
     const holeX = polygonHole.x ?? 0
     const holeY = polygonHole.y ?? 0
+    const ccwRotation = polygonHole.ccw_rotation ?? 0
+
+    // pad_outline and the hole offset are relative to the hole position in
+    // the pad's local frame; ccw_rotation rotates that frame about the hole
+    const rotateLocal = (px: number, py: number) =>
+      rotatePointCcwDeg(px, py, ccwRotation)
 
     // Transform polygon pad outline points
-    const padPoints = padOutline.map((point: { x: number; y: number }) =>
-      applyToPoint(transform, [holeX + point.x, holeY + point.y]),
-    )
+    const padPoints = padOutline.map((point: { x: number; y: number }) => {
+      const rotated = rotateLocal(point.x, point.y)
+      return applyToPoint(transform, [holeX + rotated.x, holeY + rotated.y])
+    })
     const padPointsString = padPoints
       .map((p: number[]) => p.join(","))
       .join(" ")
 
     // Calculate hole position with offset
+    const rotatedOffset = rotateLocal(
+      polygonHole.hole_offset_x,
+      polygonHole.hole_offset_y,
+    )
     const [holeCenterX, holeCenterY] = applyToPoint(transform, [
-      holeX + polygonHole.hole_offset_x,
-      holeY + polygonHole.hole_offset_y,
+      holeX + rotatedOffset.x,
+      holeY + rotatedOffset.y,
     ])
 
     // Helper function to create hole SVG object based on hole_shape

--- a/lib/utils/rotate-point.ts
+++ b/lib/utils/rotate-point.ts
@@ -1,0 +1,18 @@
+/**
+ * Rotates a point counterclockwise around the origin by the given angle in
+ * degrees. Used for pad geometry that is stored relative to a pad center and
+ * rotated by a `ccw_rotation` field in circuit coordinates.
+ */
+export const rotatePointCcwDeg = (
+  x: number,
+  y: number,
+  ccwRotationDegrees: number,
+): { x: number; y: number } => {
+  const rad = (ccwRotationDegrees * Math.PI) / 180
+  const cos = Math.cos(rad)
+  const sin = Math.sin(rad)
+  return {
+    x: x * cos - y * sin,
+    y: x * sin + y * cos,
+  }
+}

--- a/tests/pcb/pcb-plated-hole-polygon-pad-rotation.test.ts
+++ b/tests/pcb/pcb-plated-hole-polygon-pad-rotation.test.ts
@@ -1,0 +1,107 @@
+import { test, expect } from "bun:test"
+import { convertCircuitJsonToPcbSvg } from "lib"
+import { getComprehensivePcbBounds } from "lib/pcb/get-pcb-bounds-from-circuit-json"
+
+const board = {
+  type: "pcb_board" as const,
+  pcb_board_id: "board_0",
+  center: { x: 0, y: 0 },
+  width: 40,
+  height: 40,
+  material: "fr4" as const,
+  num_layers: 2,
+  thickness: 1.6,
+}
+
+const makePolygonPadHole = (
+  pcb_plated_hole_id: string,
+  ccw_rotation: number | undefined,
+  hole_offset_x = 0,
+  hole_offset_y = 0,
+) => ({
+  type: "pcb_plated_hole" as const,
+  shape: "hole_with_polygon_pad" as const,
+  pcb_plated_hole_id,
+  hole_shape: "circle" as const,
+  hole_diameter: 1,
+  x: 0,
+  y: 0,
+  hole_offset_x,
+  hole_offset_y,
+  pad_outline: [
+    { x: -3, y: -0.5 },
+    { x: 3, y: -0.5 },
+    { x: 3, y: 0.5 },
+    { x: -3, y: 0.5 },
+  ],
+  layers: ["top", "bottom"] as ("top" | "bottom")[],
+  ...(ccw_rotation === undefined ? {} : { ccw_rotation }),
+})
+
+const parsePoints = (pointsAttr: string): Array<[number, number]> =>
+  pointsAttr
+    .split(" ")
+    .map((pair) => pair.split(",").map(Number) as [number, number])
+
+test("polygon pad renders rotated by ccw_rotation about the hole position", () => {
+  const result = convertCircuitJsonToPcbSvg([
+    board,
+    makePolygonPadHole("hole1", 90, 2, 0),
+  ])
+
+  const polygon = result.match(
+    /<polygon class="pcb-hole-outer-pad"[^>]*points="([^"]+)"/,
+  )
+  expect(polygon).not.toBeNull()
+
+  // A 6x1 bar rotated 90 degrees must be taller than it is wide
+  const points = parsePoints(polygon![1]!)
+  const xs = points.map((p) => p[0])
+  const ys = points.map((p) => p[1])
+  const width = Math.max(...xs) - Math.min(...xs)
+  const height = Math.max(...ys) - Math.min(...ys)
+  expect(height).toBeGreaterThan(width)
+
+  // Hole offset (2, 0) rotates to (0, 2) in circuit space; with the y-flip
+  // the drill renders below the pad center and horizontally centered
+  const circle = result.match(
+    /<circle class="pcb-hole-inner"[^>]*cx="([^"]+)"[^>]*cy="([^"]+)"/,
+  )
+  expect(circle).not.toBeNull()
+  const padCenterX = xs.reduce((a, b) => a + b, 0) / xs.length
+  const padCenterY = ys.reduce((a, b) => a + b, 0) / ys.length
+  expect(Math.abs(Number(circle![1]) - padCenterX)).toBeLessThan(0.01)
+  expect(Number(circle![2])).toBeLessThan(padCenterY)
+})
+
+test("polygon pad without ccw_rotation is unchanged", () => {
+  const result = convertCircuitJsonToPcbSvg([
+    board,
+    makePolygonPadHole("hole1", undefined),
+  ])
+
+  const polygon = result.match(
+    /<polygon class="pcb-hole-outer-pad"[^>]*points="([^"]+)"/,
+  )
+  expect(polygon).not.toBeNull()
+  const points = parsePoints(polygon![1]!)
+  const xs = points.map((p) => p[0])
+  const ys = points.map((p) => p[1])
+  const width = Math.max(...xs) - Math.min(...xs)
+  const height = Math.max(...ys) - Math.min(...ys)
+  expect(width).toBeGreaterThan(height)
+})
+
+test("pcb bounds account for polygon pad rotation", () => {
+  const circuitJson = [makePolygonPadHole("hole1", 90)] as any
+
+  const bounds = getComprehensivePcbBounds(circuitJson)
+  expect(bounds).not.toBeNull()
+
+  // The unrotated 6x1 bar spans x: [-3, 3], y: [-0.5, 0.5]; rotated 90
+  // degrees it spans x: [-0.5, 0.5], y: [-3, 3]
+  expect(bounds!.minX).toBeCloseTo(-0.5, 1)
+  expect(bounds!.maxX).toBeCloseTo(0.5, 1)
+  expect(bounds!.minY).toBeCloseTo(-3, 1)
+  expect(bounds!.maxY).toBeCloseTo(3, 1)
+})


### PR DESCRIPTION
Fixes #709

## What changed

- `create-svg-objects-from-pcb-plated-hole.ts`: the `hole_with_polygon_pad` branch now rotates `pad_outline` and the drill offset about the hole position by `ccw_rotation` before mapping to SVG space (matching how the oval/pill and rect-pad branches apply their rotation fields).
- `get-pcb-bounds-from-circuit-json.ts`: polygon-pad bounds points are rotated the same way.
- `create-svg-object-from-pcb-pad-pin-number.ts`: the pin-number text geometry rotates the outline before computing its centroid and carries the pad rotation into the text transform (previously hardcoded `ccwRotation: 0`).
- New shared helper `lib/utils/rotate-point.ts` (`rotatePointCcwDeg`) used by all three.

## Why

`circuit-json` defines `ccw_rotation` on `PcbHoleWithPolygonPad`, and core now emits it for rotated components (tscircuit/core#3736, fixing tscircuit/core#3647). Consumers must apply it; otherwise a `<chip pcbRotation={90}>` renders its polygon pads unrotated while its rect pads rotate, and DRC-adjacent bounds disagree with the drawn geometry.

## Tests

`tests/pcb/pcb-plated-hole-polygon-pad-rotation.test.ts` (3 tests): a 6x1 bar pad with `ccw_rotation: 90` renders taller than wide with the drill offset rotated and centered; the no-rotation case is byte-identical in shape to before; and rotated bounds flip the 6x1 extents to 1x6. All 358 tests pass (355 existing unaffected — rotation only activates when `ccw_rotation` is set), `biome format` clean, `tsc --noEmit` clean.