### PR TITLE
Drop non-finite values before writing SVG r/font-size attributes

### DIFF
--- a/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-keepout.ts
+++ b/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-keepout.ts
@@ -188,6 +188,9 @@ export function createSvgObjectsFromPcbKeepout(
       ])
       const scaledRadius = circleKeepout.radius * Math.abs(transform.a)
 
+      // r="NaN" is not a valid SVG length; renderers discard the element.
+      if (!Number.isFinite(scaledRadius)) continue
+
       const backgroundAttributes = {
         ...createKeepoutBaseAttributes(
           circleKeepout.pcb_keepout_id,

--- a/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-plated-hole.ts
+++ b/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-plated-hole.ts
@@ -14,6 +14,18 @@ type HoleWithRectPadOffsets = {
   hole_offset_y?: number
 }
 
+
+// Drop any circle whose radius is non-finite: r="NaN" is not a valid
+// SVG length and renderers silently discard the whole element, which
+// makes drills disappear without any visible error.
+function dropNonFiniteRadiusCircles(objects: SvgObject[]): SvgObject[] {
+  return objects.filter((obj) => {
+    if (obj.name !== "circle") return true
+    const r = (obj.attributes as any)?.r
+    return r === undefined || Number.isFinite(Number(r))
+  })
+}
+
 export function createSvgObjectsFromPcbPlatedHole(
   hole: PcbPlatedHole,
   ctx: PcbContext,
@@ -197,7 +209,7 @@ export function createSvgObjectsFromPcbPlatedHole(
           "data-pcb-layer": "through",
           ...padDataAttributes,
         },
-        children,
+        children: dropNonFiniteRadiusCircles(children),
         value: "",
       },
     ]
@@ -262,7 +274,7 @@ export function createSvgObjectsFromPcbPlatedHole(
           "data-pcb-layer": "through",
           ...padDataAttributes,
         },
-        children,
+        children: dropNonFiniteRadiusCircles(children),
         value: "",
       },
     ]
@@ -383,7 +395,7 @@ export function createSvgObjectsFromPcbPlatedHole(
           "data-pcb-layer": "through",
           ...padDataAttributes,
         },
-        children,
+        children: dropNonFiniteRadiusCircles(children),
         value: "",
       },
     ]
@@ -590,7 +602,7 @@ export function createSvgObjectsFromPcbPlatedHole(
           "data-pcb-layer": "through",
           ...padDataAttributes,
         },
-        children,
+        children: dropNonFiniteRadiusCircles(children),
         value: "",
       },
     ]
@@ -757,7 +769,7 @@ export function createSvgObjectsFromPcbPlatedHole(
           "data-pcb-layer": "through",
           ...padDataAttributes,
         },
-        children,
+        children: dropNonFiniteRadiusCircles(children),
         value: "",
       },
     ]
@@ -928,7 +940,7 @@ export function createSvgObjectsFromPcbPlatedHole(
           "data-pcb-layer": "through",
           ...padDataAttributes,
         },
-        children,
+        children: dropNonFiniteRadiusCircles(children),
         value: "",
       },
     ]

--- a/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-silkscreen-text.ts
+++ b/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-silkscreen-text.ts
@@ -299,7 +299,9 @@ export function createSvgObjectsFromPcbSilkscreenText(
           value: "",
           attributes: {
             x: "0",
-            ...(idx > 0 ? { dy: transformedFontSize.toString() } : {}),
+            ...(idx > 0 && Number.isFinite(transformedFontSize)
+              ? { dy: transformedFontSize.toString() }
+              : {}),
           },
           children: [
             {
@@ -323,7 +325,11 @@ export function createSvgObjectsFromPcbSilkscreenText(
         dy: "0",
         fill: silkscreenColor,
         "font-family": "Arial, sans-serif",
-        "font-size": transformedFontSize.toString(),
+        // font-size="NaN" is not a valid SVG length; omit it so the
+        // text renders at the inherited default size instead of vanishing.
+        ...(Number.isFinite(transformedFontSize)
+          ? { "font-size": transformedFontSize.toString() }
+          : {}),
         "text-anchor": textAnchor,
         "dominant-baseline": dominantBaseline,
         transform: matrixToString(textTransform),

--- a/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-via.ts
+++ b/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-via.ts
@@ -12,6 +12,42 @@ export function createSvgObjectsFromPcbVia(hole: PCBVia, ctx: PcbContext): any {
 
   const outerRadius = Math.min(scaledOuterWidth, scaledOuterHeight) / 2
   const innerRadius = Math.min(scaledHoleWidth, scaledHoleHeight) / 2
+
+  // Skip any circle whose radius is non-finite: r="NaN" is not a valid
+  // SVG length and renderers silently discard the whole element.
+  const children = []
+  if (Number.isFinite(outerRadius)) {
+    children.push({
+      name: "circle",
+      type: "element",
+      attributes: {
+        class: "pcb-hole-outer",
+        fill: colorMap.copper.top,
+        cx: x.toString(),
+        cy: y.toString(),
+        r: outerRadius.toString(),
+        "data-type": "pcb_via",
+        "data-pcb-layer": "top",
+      },
+    })
+  }
+  if (Number.isFinite(innerRadius)) {
+    children.push({
+      name: "circle",
+      type: "element",
+      attributes: {
+        class: "pcb-hole-inner",
+        fill: colorMap.drill,
+        cx: x.toString(),
+        cy: y.toString(),
+        r: innerRadius.toString(),
+        "data-type": "pcb_via",
+        "data-pcb-layer": "drill",
+      },
+    })
+  }
+  if (children.length === 0) return []
+
   return {
     name: "g",
     type: "element",
@@ -19,34 +55,6 @@ export function createSvgObjectsFromPcbVia(hole: PCBVia, ctx: PcbContext): any {
       "data-type": "pcb_via",
       "data-pcb-layer": "through",
     },
-    children: [
-      {
-        name: "circle",
-        type: "element",
-        attributes: {
-          class: "pcb-hole-outer",
-          fill: colorMap.copper.top,
-          cx: x.toString(),
-          cy: y.toString(),
-          r: outerRadius.toString(),
-          "data-type": "pcb_via",
-          "data-pcb-layer": "top",
-        },
-      },
-      {
-        name: "circle",
-        type: "element",
-        attributes: {
-          class: "pcb-hole-inner",
-          fill: colorMap.drill,
-
-          cx: x.toString(),
-          cy: y.toString(),
-          r: innerRadius.toString(),
-          "data-type": "pcb_via",
-          "data-pcb-layer": "drill",
-        },
-      },
-    ],
+    children,
   }
 }

--- a/tests/pcb/non-finite-dimensions.test.ts
+++ b/tests/pcb/non-finite-dimensions.test.ts
@@ -1,0 +1,101 @@
+import { test, expect } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToPcbSvg } from "lib"
+
+// Regression for https://github.com/tscircuit/circuit-to-svg/issues/634
+// and https://github.com/tscircuit/circuit-to-svg/issues/636
+// Non-finite dimensions must never be written into SVG attributes:
+// r="NaN" / font-size="NaN" are not valid SVG lengths and renderers
+// silently discard the whole element.
+
+const board = {
+  type: "pcb_board",
+  pcb_board_id: "board_0",
+  center: { x: 0, y: 0 },
+  width: 20,
+  height: 20,
+  thickness: 1.6,
+  num_layers: 2,
+  material: "fr4",
+} as const
+
+test("via with NaN hole diameter emits no NaN attributes", () => {
+  const circuit: AnyCircuitElement[] = [
+    board as any,
+    {
+      type: "pcb_via",
+      pcb_via_id: "via_0",
+      x: 5,
+      y: 5,
+      outer_diameter: 0.6,
+      hole_diameter: Number.NaN,
+      layers: ["top", "bottom"],
+      from_layer: "top",
+      to_layer: "bottom",
+    } as any,
+  ]
+
+  const svg = convertCircuitJsonToPcbSvg(circuit)
+  expect(svg).not.toContain("NaN")
+  // copper outer circle still renders
+  expect(svg).toContain("pcb-hole-outer")
+})
+
+test("plated hole with NaN hole diameter emits no NaN attributes", () => {
+  const circuit: AnyCircuitElement[] = [
+    board as any,
+    {
+      type: "pcb_plated_hole",
+      pcb_plated_hole_id: "ph_0",
+      shape: "circle",
+      x: 0,
+      y: 0,
+      outer_diameter: 1.2,
+      hole_diameter: Number.NaN,
+      layers: ["top", "bottom"],
+    } as any,
+  ]
+
+  const svg = convertCircuitJsonToPcbSvg(circuit)
+  expect(svg).not.toContain("NaN")
+  expect(svg).toContain("pcb-hole-outer")
+})
+
+test("silkscreen text with NaN font size renders without font-size=NaN", () => {
+  const circuit: AnyCircuitElement[] = [
+    board as any,
+    {
+      type: "pcb_silkscreen_text",
+      pcb_silkscreen_text_id: "silk_0",
+      pcb_component_id: "comp_0",
+      text: "hi",
+      font: "tscircuit2024",
+      font_size: Number.NaN,
+      layer: "top",
+      anchor_position: { x: 3, y: 3 },
+      anchor_alignment: "center",
+      ccw_rotation: 0,
+    } as any,
+  ]
+
+  const svg = convertCircuitJsonToPcbSvg(circuit)
+  expect(svg).not.toContain("NaN")
+  expect(svg).toContain("hi")
+})
+
+test("circular keepout with NaN radius emits no NaN attributes", () => {
+  const circuit: AnyCircuitElement[] = [
+    board as any,
+    {
+      type: "pcb_keepout",
+      pcb_keepout_id: "ko_0",
+      shape: "circle",
+      center: { x: 5, y: 5 },
+      radius: Number.NaN,
+      layers: ["top"],
+    } as any,
+  ]
+
+  const svg = convertCircuitJsonToPcbSvg(circuit)
+  expect(svg).not.toContain("NaN")
+})


### PR DESCRIPTION
Fixes #634, fixes #636.

Non-finite via/plated-hole diameters, silkscreen font sizes, and keepout radii were written straight into the SVG as r="NaN" / font-size="NaN". Those are invalid lengths, so renderers silently discard the shapes (e.g. drill holes go missing).

Fix: guard non-finite emissions following the repo's existing conventions - drop non-finite radius circles for vias/plated-holes, omit font-size/dy for non-finite silkscreen text sizes, and skip non-finite keepout circles.

Tests: 4 new regression tests, all fail before the fix; full suite 358 pass / 0 fail after, no snapshot changes.

---
*This PR was prepared by an AI assistant operated on behalf of a human (see profile bio). The fix and regression tests were implemented and verified by the assistant; submission is human-authorized.*